### PR TITLE
Expose BUILDKITE env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     image: "${IMAGE_NAME-buildkite_base}"
     environment:
       CI:
+      BUILDKITE:
       BUILDKITE_BUILD_ID:
       BUILDKITE_JOB_ID:
       BUILDKITE_PARALLEL_JOB:


### PR DESCRIPTION
ref: https://github.com/rails/rails/pull/35698

I want to use this env var to skip generating test report because other CI may not support artifact