### PR TITLE
Retry if agent was lost

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -156,6 +156,7 @@ def step_for(subdirectory, rake_task, ruby: nil, service: "default")
     "soft_fail" => SOFT_FAIL.include?(ruby),
     "agents" => { "queue" => QUEUE },
     "artifact_paths" => ["test-reports/*/*.xml"],
+    "retry" => { "automatic" => { "exit_status" => -1, "limit" => 2 } },
   }
 
   yield hash if block_given?


### PR DESCRIPTION
ref: https://github.com/rails/rails/pull/35698#issuecomment-490568189

Sometimes buildkite agent was lost.

- https://buildkite.com/rails/rails/builds/61077#6e5a869c-bc99-4df4-ae9f-7433e2a39638
- https://buildkite.com/rails/rails/builds/61018#b5746af9-adf3-4e91-871b-a5af02b7ba72

![image](https://user-images.githubusercontent.com/1796864/57579113-4caef780-74d2-11e9-8a56-ce2e57f8d0d4.png)

I asked buildkite support team and I got this advice:

> Hey there Fumiaki — thanks for reaching out! 👋🏼
>
> Just looking into that particular job it seems that it exited with “Exited with status -1 (agent lost)”.
>
> Agent lost means that the agent process disappeared while processing the job — typically this shows up with autoscaling agents where they can come and go and be terminated by the autoscaling process.
>
> It’s possible to work around this with retry rules for steps that can detect this and run the step again, there is a bit more info on this in our docs.
>
> Hope that clears that up!

I'd like to add this retry setting as described in the doc.