### PR TITLE
Use `default-mysql-client` instead of `mysql-client`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ RUN echo "--- :ruby: Updating RubyGems and Bundler" \
         ) \
     #  specific dependencies for the rails build
     && apt-get install -y --no-install-recommends \
-        postgresql-client mysql-client sqlite3 \
+        postgresql-client default-mysql-client sqlite3 \
         git nodejs yarn lsof \
         ffmpeg mupdf mupdf-tools poppler-utils \
     # await (for waiting on dependent services)


### PR DESCRIPTION
Currently, Rails' build fails because `mysql-client` package does not found.
https://buildkite.com/rails/rails/builds/62162#29082d6b-4dc8-4888-97e4-d39094ac563e/249-339

It seems strech has `mysql-client`, but buster does not have `mysql-client`.
https://packages.debian.org/stretch/mysql-client
https://packages.debian.org/buster/mysql-client

As `default-mysql-client` that `mysql-client` depended on seems to be in both, so fixed to use that instead.
https://packages.debian.org/stretch/default-mysql-client
https://packages.debian.org/buster/default-mysql-client