### PR TITLE
Use master-nightly-bionic Ruby Docker image tag

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -70,9 +70,9 @@ end
 
 ONE_RUBY = (RUBIES - SOFT_FAIL).last || RUBIES.last
 
-TRUNK_RUBY = "rubylang/ruby:trunk-nightly-bionic"
-RUBIES << TRUNK_RUBY
-SOFT_FAIL << TRUNK_RUBY
+MASTER_RUBY = "rubylang/ruby:master-nightly-bionic"
+RUBIES << MASTER_RUBY
+SOFT_FAIL << MASTER_RUBY
 
 
 STEPS = []
@@ -97,7 +97,7 @@ def step_for(subdirectory, rake_task, ruby: nil, service: "default")
   label = +"#{subdirectory} #{rake_task.sub(/[:_]test|test:/, "")}"
   label.sub!(/ test/, "")
   if ruby
-    short_ruby = ruby == TRUNK_RUBY ? "trunk" : ruby.sub(/^ruby:|:latest$/, "")
+    short_ruby = ruby == MASTER_RUBY ? "master" : ruby.sub(/^ruby:|:latest$/, "")
     label << " (#{short_ruby})"
   end
 


### PR DESCRIPTION
For https://github.com/rails/rails/issues/36590.

https://hub.docker.com/r/rubylang/ruby/tags?name=nightly-bionic

The Ruby Docker image tags have been renamed to reflect the move from Subversion to Git: https://github.com/ruby/ruby-docker-images/pull/10

The latest build on the new tag includes this commit, which should get Rails' CI building again: https://github.com/ruby/ruby/commit/a569bc09e25a2ba813d0bec1228d9ff65330a3db