### PR TITLE
Allow postgres container to start with no password

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,8 @@ services:
 
   postgres:
     image: "${POSTGRES_IMAGE-postgres:alpine}"
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: "trust"
 
   rabbitmq:
     image: rabbitmq:alpine


### PR DESCRIPTION
The postgres image no longer starts by default without a password set:

https://github.com/docker-library/postgres/pull/658

Since this change, Rails' CI is failing on all postgresql steps:

https://buildkite.com/rails/rails/builds/67011

Setting `POSTGRES_HOST_AUTH_METHOD=trust` restores the old behaviour. It's roughly equivalent to `MYSQL_ALLOW_EMPTY_PASSWORD`, which we already set:

https://github.com/rails/buildkite-config/blob/f94d68290a44c5591587fe261135f862cb76209e/docker-compose.yml#L106-L107