### PR TITLE
Add ruby:master-debug-nightly-bionic

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -73,8 +73,8 @@ end
 
 ONE_RUBY = RUBIES.last || SOFT_FAIL.last
 
-MASTER_RUBY = "rubylang/ruby:master-nightly-bionic"
-SOFT_FAIL << MASTER_RUBY
+MASTER_RUBIES = ["rubylang/ruby:master-nightly-bionic", "ruby:master-debug-nightly-bionic"]
+SOFT_FAIL.concat MASTER_RUBIES
 
 # Run steps for newer Rubies first.
 RUBIES.reverse!
@@ -105,7 +105,16 @@ def step_for(subdirectory, rake_task, ruby: nil, service: "default")
   label = +"#{subdirectory} #{rake_task.sub(/[:_]test|test:/, "")}"
   label.sub!(/ test/, "")
   if ruby
-    short_ruby = ruby == MASTER_RUBY ? "master" : ruby.sub(/^ruby:|:latest$/, "")
+    short_ruby = 
+      case ruby
+      when MASTER_RUBIES[0]
+        'master'
+      when MASTER_RUBIES[1]
+        'master-debug'
+      else
+        ruby.sub(/^ruby:|:latest$/, "")
+      end
+
     label << " (#{short_ruby})"
   end
 

--- a/pipeline-generate
+++ b/pipeline-generate
@@ -73,7 +73,7 @@ end
 
 ONE_RUBY = RUBIES.last || SOFT_FAIL.last
 
-MASTER_RUBIES = ["rubylang/ruby:master-nightly-bionic", "ruby:master-debug-nightly-bionic"]
+MASTER_RUBIES = ["rubylang/ruby:master-nightly-bionic", "rubylang/ruby:master-debug-nightly-bionic"]
 SOFT_FAIL.concat MASTER_RUBIES
 
 # Run steps for newer Rubies first.


### PR DESCRIPTION
I'm Koichi working on MRI development.

We prepared `ruby:master-debug-nightly-bionic` docker image which provides MRI compiled with enabling assertions.
Assertions check the healthiness of an interpreter internal state more aggressively, but it is slow than normal built interpreter.

Of course we are using this assertion enabled interpreter for MRI's CI.
However we want to try further more tests on assertion enabled interpreter.
If Rails framework, the big and most popular Ruby software try it, it will be huge help for MRI development.
The drawback is more CPU time is needed.

Thank you for your consideration,
Koichi