### PR TITLE
Use `rubylang/ruby:master-nightly-focal` docker image

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -73,7 +73,7 @@ end
 
 ONE_RUBY = RUBIES.last || SOFT_FAIL.last
 
-MASTER_RUBY = "rubylang/ruby:master-nightly-bionic"
+MASTER_RUBY = "rubylang/ruby:master-nightly-focal"
 SOFT_FAIL << MASTER_RUBY
 
 # Run steps for newer Rubies first.


### PR DESCRIPTION
Starting from Ruby 3, rubylang/ruby docker image uses Ubuntu focal by default.

Refer https://github.com/ruby/ruby-docker-images/pull/20

Confirmed it works without failures or errors.
```ruby
$ git clone https://github.com/rails/rails.git
$ cd rails
$ git clone https://github.com/rails/buildkite-config .buildkite/
$ RUBY_IMAGE=rubylang/ruby:master-nightly-focal docker-compose -f .buildkite/docker-compose.yml build base \
&& CI=1 docker-compose -f .buildkite/docker-compose.yml run default runner actionpack 'rake test'
... snip ...
Finished in 8.669211s, 388.9627 runs/s, 1887.2537 assertions/s.
3372 runs, 16361 assertions, 0 failures, 0 errors, 0 skips
```