### PR TITLE
Update dockerhub URL

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -55,7 +55,7 @@ MAX_RUBY =
   end
 
 def available_tags_for_image(image)
-  uri = URI("https://registry.hub.docker.com/v1/repositories/#{image}/tags")
+  uri = URI("https://hub.docker.com/v1/repositories/#{image}/tags")
   json = Net::HTTP.get(uri)
   JSON.parse(json).map { |x| x["name"] }
 end


### PR DESCRIPTION
https://registry.hub.docker.com/v1/repositories/ruby/tags now redirects to https://hub.docker.com/v1/repositories/ruby/tags

Since `Net::HTTP.get` doesn't follow redirects by default, this is now breaking CI, eg. https://buildkite.com/rails/rails/builds/78494#a67e145d-d58b-40c2-8845-080fd4cadeea