### PR TITLE
Use Node v16.x as v10.x is no longer supported

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "--- :ruby: Updating RubyGems and Bundler" \
     && echo "deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     # Node apt sources
     && curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add - \
-    && echo "deb http://deb.nodesource.com/node_10.x ${codename} main" > /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb http://deb.nodesource.com/node_16.x ${codename} main" > /etc/apt/sources.list.d/nodesource.list \
     # Yarn apt sources
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add - \
     && echo "deb http://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \


### PR DESCRIPTION
The latest Ruby Docker image upgraded Debian to Bullseye:
https://github.com/docker-library/ruby/pull/357

Bullseye no longer supports Node v10.x, which cause NPM to not be
installed, resulting in failing builds.

As Node v10.x is no longer supported we should switch to a supported
version. Active support for v14 ends in November 2021, so we might as
well switch to v16. See: https://endoflife.date/nodejs

Steps to reproduce:

    $ git clone https://github.com/rails/rails
    $ cd rails
    $ git clone https://github.com/rails/buildkite-config .buildkite/
    $ RUBY_IMAGE=ruby:3.0.2 docker-compose -f .buildkite/docker-compose.yml build base && CI=1 docker-compose -f .buildkite/docker-compose.yml run actionview runner actionview 'rake test:ujs'