### PR TITLE
Workaround PostgreSQL related CI failures by using `postgres:13` image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       - "./mysql-initdb.d:/docker-entrypoint-initdb.d"
 
   postgres:
-    image: "${POSTGRES_IMAGE-postgres:alpine}"
+    image: "${POSTGRES_IMAGE-postgres:13}"
     environment:
       POSTGRES_HOST_AUTH_METHOD: "trust"
 


### PR DESCRIPTION
This commit workaround CI failures since
https://buildkite.com/rails/rails/builds/81481#a9f5a3f2-46a2-44f2-a9b4-ca15516e04cb/1099-1110

I have not found why these CI are failing now yet (may be related to
PostgreSQL 14 release but not sure), this commit should workaround CI failures.

* Steps to reproduce with the current `postgres:alpine` image
```
git clone https://github.com/rails/rails
cd rails/
git clone https://github.com/rails/buildkite-config .buildkite/
RUBY_IMAGE=ruby:3.0 docker-compose -f .buildkite/docker-compose.yml build base &&
CI=1 POSTGRES_IMAGE=postgres:alpine docker-compose -f .buildkite/docker-compose.yml run postgresdb runner activerecord 'rake db:postgresql:rebuild test:postgresql'
```

- Result with the current `postgres:alpine` image

```
Failure:
PostgresqlEnumTest#test_schema_dump [/rails/activerecord/test/cases/adapters/postgresql/enum_test.rb:107]:

ActiveRecord::Schema.define(version: 0) do

  # These are extensions that must be enabled in order to support this database
  enable_extension "hstore"
  enable_extension "ltree"
  enable_extension "pgcrypto"
  enable_extension "plpgsql"
  enable_extension "uuid-ossp"

  # Custom types defined in this database.
  # Note that some types may not work with other database engines. Be careful if changing database.
  create_enum "mood", ["happy", "ok", "sad"]

  create_table "postgresql_enums", force: :cascade do |t|
    t.enum "current_mood", enum_type: "mood"
    t.enum "good_mood", default: "happy", null: false, enum_type: "mood"
  end

end

rails test rails/activerecord/test/cases/adapters/postgresql/enum_test.rb:100
... snip ...
8295 runs, 26723 assertions, 1 failures, 0 errors, 9 skips
```

- Steps to reproduce with the `postgres:13` image
```
git clone https://github.com/rails/rails
cd rails/
git clone https://github.com/rails/buildkite-config .buildkite/
RUBY_IMAGE=ruby:3.0 docker-compose -f .buildkite/docker-compose.yml build base &&
CI=1 POSTGRES_IMAGE=postgres:13 docker-compose -f .buildkite/docker-compose.yml run postgresdb runner activerecord 'rake db:postgresql:rebuild test:postgresql'
```

- Result with the `postgres:13` image
```
8295 runs, 26726 assertions, 0 failures, 0 errors, 9 skips
```