### PR TITLE
Ignore guides for 6.0 and below

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -279,7 +279,7 @@ end
 if RAILS_VERSION < Gem::Version.new("7.x") && RAILS_VERSION >= Gem::Version.new("6.1")
   STEPS.delete_if { |s| s["label"] == "guides (2.7)" || s["label"] == "guides (3.0)" }
 end
-STEPS.delete_if { |s| s["label"] =~ /^guides/ } if RAILS_VERSION < Gem::Version.new("5.x")
+STEPS.delete_if { |s| s["label"] =~ /^guides/ } if RAILS_VERSION <= Gem::Version.new("6.0")
 
 ###
 


### PR DESCRIPTION
The guides fail due to the test scripts for the bug report templates.
They don't always bundle but they aren't needed for applications to be
confident that 5-2-stable and 6-0-stable are passing CI.