### PR TITLE
Fix config for guides

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -279,7 +279,7 @@ end
 if RAILS_VERSION < Gem::Version.new("7.x") && RAILS_VERSION >= Gem::Version.new("6.1")
   STEPS.delete_if { |s| s["label"] == "guides (2.7)" || s["label"] == "guides (3.0)" }
 end
-STEPS.delete_if { |s| s["label"] =~ /^guides/ } if RAILS_VERSION <= Gem::Version.new("6.0")
+STEPS.delete_if { |s| s["label"] =~ /^guides/ } if RAILS_VERSION < Gem::Version.new("6.1")
 
 ###
 


### PR DESCRIPTION
We want to skip guides on 6.0 and below. I got the configuration wrong
here in my last commit, it should be anything less than 6.1.