### PR TITLE
Use "mariadb:10.7" to workaround CI failure

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -249,7 +249,7 @@ if RAILS_VERSION >= Gem::Version.new("5.x")
       if RAILS_VERSION < Gem::Version.new("6.x")
         "mariadb:10.2"
       else
-        "mariadb:latest"
+        "mariadb:10.7"
       end
   end
 end


### PR DESCRIPTION
This commit uses "mariadb:10.7" for Rails CI
until https://github.com/MariaDB/mariadb-docker/issues/434 is resolved.

I assume this "mariadb:latest" now points "mariadb:10.8"
after MariaDDB 10.8.3 has been released as the first GA version of
MariaDB 10.8, https://mariadb.com/kb/en/mariadb-1083-release-notes/

Refer to https://github.com/rails/rails/issues/45167