### PR TITLE
Revert "Use "mariadb:10.7" to workaround CI failure"

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -249,7 +249,7 @@ if RAILS_VERSION >= Gem::Version.new("5.x")
       if RAILS_VERSION < Gem::Version.new("6.x")
         "mariadb:10.2"
       else
-        "mariadb:10.7"
+        "mariadb:latest"
       end
   end
 end


### PR DESCRIPTION
Reverts rails/buildkite-config#17

Discussed offline with Buildkite and now Rails CI runs https://github.com/buildkite/elastic-ci-stack-for-aws/releases/tag/v5.8.2 that uses Docker 20.10.14. 

Docker 20.10.14 should run `mariadb:latest` image that is MariaDB 10.8 without issues.
