### PR TITLE
Add mysql 5.7 build

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -242,6 +242,10 @@ if RAILS_VERSION >= Gem::Version.new("6.1.x")
     x["env"]["MYSQL_PREPARED_STATEMENTS"] = "true"
   end
 end
+step_for("activerecord", "mysql2:test", service: "mysqldb") do |x|
+  x["label"] += " [mysql_5_7]"
+  x["env"]["MYSQL_IMAGE"] = "mysql:5.7"
+end
 if RAILS_VERSION >= Gem::Version.new("5.x")
   step_for("activerecord", "mysql2:test", service: "mysqldb") do |x|
     x["label"] += " [mariadb]"


### PR DESCRIPTION
Currently we're only running mysql 8 builds which has resulted in
merging broken changes in mysql 5.7 that we end up finding when we run
tests locally. Running with both 8 and 5.7 will ensure that all new
features to active record are supported by both databases, or cases
where they aren't supported, we can handle those cases in PRs.