### PR TITLE
Use a static list of usable ruby versions

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -24,6 +24,7 @@ ARTIFACTS_PLUGIN = "artifacts#v1.2.0"
 REPO_ROOT = Pathname.new(ARGV.shift || File.expand_path("../..", __FILE__))
 
 REPO_ROOT.join("rails.gemspec").read =~ /required_ruby_version[^0-9]+([0-9]+\.[0-9]+)/
+RUBY_MINORS = %w(2.4 2.5 2.6 2.7 3.0 3.1).map { |v| Gem::Version.new(v) }
 MIN_RUBY = Gem::Version.new($1 || "2.0")
 
 RAILS_VERSION = Gem::Version.new(File.read(REPO_ROOT.join("RAILS_VERSION")))
@@ -54,22 +55,11 @@ MAX_RUBY =
     Gem::Version.new("2.7")
   end
 
-def available_tags_for_image(image)
-  uri = URI("https://hub.docker.com/v1/repositories/#{image}/tags")
-  json = Net::HTTP.get(uri)
-  JSON.parse(json).map { |x| x["name"] }
-end
 
 RUBIES = []
 SOFT_FAIL = []
 
-available_tags_for_image("ruby").
-  grep(/\A[0-9]+\.[0-9]+\z/).
-  map { |s| Gem::Version.new(s) }.
-  select { |v| v >= MIN_RUBY }.
-  sort.
-  each do |v|
-
+RUBY_MINORS.select { |v| v >= MIN_RUBY }.each do |v|
   image = "ruby:#{v}"
 
   if MAX_RUBY && v > MAX_RUBY && !(MAX_RUBY.approximate_recommendation === v)


### PR DESCRIPTION
Instead of a Docker API call.

CI was down because that docker API is being deprecated. I started upgrading to the V2 API, but it only returns 100 tags per page, and there is currently almost 1k tags.

That doesn't seem sustainable, so I think a simple hardcoded list is more than good enough.

Alternatively, I know that there is a flat file super easy to parse with all the ruby release versions somewhere on `ruby-lang.org`, I just can't remember where.

