### PR TITLE
Support `rake test:isolated` for Action Text

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -188,6 +188,7 @@ end
   activemodel     test                default
   activesupport   test                default
   actionview      test                default
+  actiontext      test                default
   activejob       test                default
   activerecord    mysql:test          mysqldb
   activerecord    mysql2:test         mysqldb
@@ -215,7 +216,6 @@ end
   actioncable     test                postgresdb
   activestorage   test                default
   actionmailbox   test                default
-  actiontext      test                default
   guides          test                default
 ).each_slice(3) do |dir, task, service|
   steps_for(dir, task, service: service)


### PR DESCRIPTION
This commit runs `rake test:isolated` for Action Text once https://github.com/rails/rails/pull/46129 is merged.