### PR TITLE
Fix ruby master builds

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -71,7 +71,7 @@ end
 
 ONE_RUBY = RUBIES.last || SOFT_FAIL.last
 
-MASTER_RUBY = "rubylang/ruby:master-nightly-focal"
+MASTER_RUBY = "rubylang/ruby:latest"
 SOFT_FAIL << MASTER_RUBY
 
 # Adds yjit: onto the master ruby image string so we


### PR DESCRIPTION
It looks like the tag name changed so `master-nightly-focal` no longer exists. I think we want `latest` instead now.