### PR TITLE
Use "rubylang/ruby:master-nightly-focal" to test Ruby 3.2 dev

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -71,7 +71,7 @@ end
 
 ONE_RUBY = RUBIES.last || SOFT_FAIL.last
 
-MASTER_RUBY = "rubylang/ruby:latest"
+MASTER_RUBY = "rubylang/ruby:master-nightly-focal"
 SOFT_FAIL << MASTER_RUBY
 
 # Adds yjit: onto the master ruby image string so we


### PR DESCRIPTION
"rubylang/ruby:latest" actually runs the latest released version of Ruby like 3.1.3

Once https://github.com/rails/rails/pull/46711 has been merged to Rails main branch, "rubylang/ruby:master-nightly-focal" can proceed Rails CI to test Rails against Ruby 3.2.dev