### PR TITLE
Apply MAX_RUBY version to 3.1 for Rails 6.1

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -53,6 +53,8 @@ MAX_RUBY =
     Gem::Version.new("2.6")
   when Gem::Requirement.new("< 6.1")
     Gem::Version.new("2.7")
+  when Gem::Requirement.new("< 7.0")
+    Gem::Version.new("3.1")
   end
 
 


### PR DESCRIPTION
Ruby 3.2 was released on Dec 25, 2022. At that time Rails 6.1.Z only accepts security issue fixes.

https://guides.rubyonrails.org/maintenance_policy.html

Technically it already fails after https://github.com/rails/buildkite-config/pull/25 https://buildkite.com/rails/rails/builds/92168#0185826c-5d60-4c1e-b7bb-793864701853