### PR TITLE
Bump minimum rubygems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ${RUBY_IMAGE:-ruby:latest}
 ARG BUNDLER
 ARG RUBYGEMS
 RUN echo "--- :ruby: Updating RubyGems and Bundler" \
-    && (gem update --system ${RUBYGEMS:-} || gem update --system 2.7.8) \
+    && (gem update --system ${RUBYGEMS:-} || gem update --system 3.3.3) \
     && (gem install bundler -v "${BUNDLER:->= 0}" || gem install bundler -v "< 2") \
     && ruby --version && gem --version && bundle --version \
     && echo "--- :package: Installing system deps" \


### PR DESCRIPTION
On Rails 6-0-stable we're not able to build new Rubies (3.1+) because the version of Rubygems is too old. I do not understand why it's falling back but I hope this will fix the issue we're seeing.

Error message:

```
ERROR:  rubygems 3.2.9 is not supported on 3.3.0. The oldest version supported by this ruby is 3.3.3
ERROR:  rubygems 2.7.8 is not supported on 3.3.0. The oldest version supported by this ruby is 3.3.3
```

Build ex: https://buildkite.com/rails/rails/builds/92217#018587aa-6df9-40a4-bf5d-05772f425cc4