### PR TITLE
Revert "Lock RubyGems and Bundler version"

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -34,8 +34,6 @@ BUNDLER =
     "< 2"
   when Gem::Requirement.new("< 6.1")
     "< 2.2.10"
-  else
-    "< 2.4.4"
   end
 RUBYGEMS =
   case RAILS_VERSION
@@ -43,8 +41,6 @@ RUBYGEMS =
     "2.6.13"
   when Gem::Requirement.new("< 6.1")
     "3.2.9"
-  else
-    "3.4.3"
   end
 
 MAX_RUBY =


### PR DESCRIPTION
Reverts rails/buildkite-config#30

Bundler 2.4.5 has been released that fixes https://github.com/rubygems/rubygems/pull/6285

https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md#245-january-21-2023

We should not need to lock/pin Bunder and RubyGems versions anymore.