### PR TITLE
Skip guides for Rails 6.1

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -328,7 +328,7 @@ end
 if RAILS_VERSION < Gem::Version.new("7.x") && RAILS_VERSION >= Gem::Version.new("6.1")
   STEPS.delete_if { |s| s["label"] == "guides (2.7)" || s["label"] == "guides (3.0)" }
 end
-STEPS.delete_if { |s| s["label"] =~ /^guides/ } if RAILS_VERSION < Gem::Version.new("6.1")
+STEPS.delete_if { |s| s["label"] =~ /^guides/ } if RAILS_VERSION < Gem::Version.new("7.0")
 
 ###
 


### PR DESCRIPTION
Rails 6.1.Z only provides the fix for security issues, not bug fixes we do not need to run bug_report_templates against Rails 6.1.z (6-1-stable branch) anymore.

This commit is based on the comment below:
https://github.com/rails/rails/pull/47411#issuecomment-1434041230

There was a similar pull request to skip guides for Rails 6.0. https://github.com/rails/buildkite-config/pull/16/files