### PR TITLE
Replace await script with docker-compose health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,9 +89,6 @@ RUN echo "--- :ruby: Updating RubyGems and Bundler" \
         postgresql-client default-mysql-client sqlite3 \
         git nodejs yarn lsof \
         ffmpeg mupdf mupdf-tools poppler-utils \
-    # await (for waiting on dependent services)
-    && curl -fLsS -o /tmp/await-linux-amd64 https://github.com/betalo-sweden/await/releases/download/v0.4.0/await-linux-amd64 \
-    && install /tmp/await-linux-amd64 /usr/local/bin/await \
     # clean up
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* \
@@ -101,8 +98,8 @@ WORKDIR /rails
 ENV RAILS_ENV=test RACK_ENV=test
 ENV JRUBY_OPTS="--dev -J-Xmx1024M"
 
-ADD .buildkite/await-all .buildkite/runner /usr/local/bin/
-RUN chmod +x /usr/local/bin/await-all /usr/local/bin/runner
+ADD .buildkite/runner /usr/local/bin/
+RUN chmod +x /usr/local/bin/runner
 
 # Wildcard ignores missing files; .empty ensures ADD always has at least
 # one valid source: https://stackoverflow.com/a/46801962

--- a/await-all
+++ b/await-all
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-exec await $(
-    getent hosts $(
-        for v in ${!AWAIT_*}; do echo ${v#AWAIT_}; done
-    ) | while read ip name; do v="AWAIT_${name}"; echo ${!v}; done
-) -- "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
 
   default: &default
     image: "${IMAGE_NAME-buildkite_base}"
-    environment:
+    environment: &default_env
       CI:
       BUILDKITE:
       BUILDKITE_BUILD_ID:
@@ -37,22 +37,14 @@ services:
       REDIS_URL: "redis://redis:6379/1"
       SELENIUM_DRIVER_URL: "http://chrome:4444/wd/hub"
 
-      AWAIT_redis: tcp://redis:6379
-      AWAIT_memcached: tcp://memcached:11211
-      AWAIT_mysql: tcp://mysql:3306
-      AWAIT_postgres: postgres://postgres@postgres:5432/postgres
-      AWAIT_rabbitmq: tcp://rabbitmq:5672
-      AWAIT_beanstalkd: tcp://beanstalkd:11300
-      AWAIT_chrome: tcp://chrome:4444
-
-    entrypoint: await-all
-
     volumes:
       - ../test-reports:/rails/test-reports
 
     depends_on:
-      - redis
-      - memcached
+      redis:
+        condition: service_healthy
+      memcached:
+        condition: service_healthy
 
     tmpfs:
       - /rails/tmp:size=1G,exec
@@ -60,67 +52,140 @@ services:
   postgresdb:
     <<: *default
     depends_on:
-      - redis
-      - memcached
-      - postgres
+      redis:
+        condition: service_healthy
+      memcached:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
 
   mysqldb:
     <<: *default
     depends_on:
-      - redis
-      - memcached
-      - mysql
+      redis:
+        condition: service_healthy
+      memcached:
+        condition: service_healthy
+      mysql:
+        condition: service_healthy
+
+  mariadb:
+    <<: *default
+    environment:
+      <<: *default_env
+      MYSQL_HOST: mariadb_service
+    depends_on:
+      redis:
+        condition: service_healthy
+      memcached:
+        condition: service_healthy
+      mariadb_service:
+        condition: service_healthy
 
   railties:
     <<: *default
     depends_on:
-      - redis
-      - memcached
-      - mysql
-      - postgres
+      redis:
+        condition: service_healthy
+      memcached:
+        condition: service_healthy
+      mysql:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
 
   activejob:
     <<: *default
     depends_on:
-      - redis
-      - memcached
-      - postgres
-      - rabbitmq
-      - beanstalkd
+      redis:
+        condition: service_healthy
+      memcached:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      beanstalkd:
+        condition: service_healthy
 
   actionview:
     <<: *default
     depends_on:
-      - redis
-      - memcached
-      - chrome
+      redis:
+        condition: service_healthy
+      memcached:
+        condition: service_healthy
+      chrome:
+        condition: service_healthy
 
   memcached:
     image: memcached:alpine
+    healthcheck:
+      test: echo stats | nc 127.0.0.1 11211
+      interval: 10s
+      retries: 60
 
   redis:
     image: redis:alpine
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
+      interval: 1s
+      timeout: 3s
+      retries: 5
 
-  mysql:
+  mysql: &mysql-defaults
     image: "${MYSQL_IMAGE-mysql:latest}"
     command: "--default-authentication-plugin=mysql_native_password"
+    healthcheck:
+      test: mysqladmin -h localhost -P 3306 ping --silent
+      interval: 10s
+      retries: 60
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     volumes:
       - "./mysql-initdb.d:/docker-entrypoint-initdb.d"
 
+  mariadb_service:
+    <<: *mysql-defaults
+    healthcheck:
+      test: healthcheck.sh --su-mysql --connect --innodb_initialized
+      interval: 10s
+      retries: 60
+
   postgres:
     image: "${POSTGRES_IMAGE-postgres:alpine}"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     environment:
       POSTGRES_HOST_AUTH_METHOD: "trust"
 
   rabbitmq:
     image: rabbitmq:alpine
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 30s
+      timeout: 30s
+      retries: 3
 
   beanstalkd:
     build:
       context: ./
       dockerfile: Dockerfile.beanstalkd
+    healthcheck:
+      test: echo -e "stats\r\n" | nc localhost 11300 || exit 1
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
 
   chrome:
-    image: selenium/standalone-chrome:latest
+    image: seleniarm/standalone-chromium:latest
+    healthcheck:
+      test: "curl -f http://localhost:4444/ui || exit 1"
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 30s

--- a/pipeline-generate
+++ b/pipeline-generate
@@ -296,7 +296,7 @@ if RAILS_VERSION >= Gem::Version.new("7.1.0.alpha")
   end
 end
 if RAILS_VERSION >= Gem::Version.new("5.x")
-  step_for("activerecord", "mysql2:test", service: "mysqldb") do |x|
+  step_for("activerecord", "mysql2:test", service: "mariadb") do |x|
     x["label"] += " [mariadb]"
     x["env"]["MYSQL_IMAGE"] =
       if RAILS_VERSION < Gem::Version.new("6.x")
@@ -307,7 +307,7 @@ if RAILS_VERSION >= Gem::Version.new("5.x")
   end
 end
 if RAILS_VERSION >= Gem::Version.new("7.1.0.alpha")
-  step_for("activerecord", "trilogy:test", service: "mysqldb") do |x|
+  step_for("activerecord", "trilogy:test", service: "mariadb") do |x|
     x["label"] += " [mariadb]"
     x["env"]["MYSQL_IMAGE"] = "mariadb:latest"
   end


### PR DESCRIPTION
This change came out of originally trying to run our CI locally on my M1 macbook.

Since the [await](https://github.com/betalo-sweden/await) script we're using only works on amd64, and is unmaintained, I tried to find an alternative. Many of the similar libraries (dockerize, etc) also only offer x86 binaries, with many going unsupported since docker-compose added health check support.

If you look around at some of their issue trackers, you will see several people who have either forked and built their own binary for arm, or just started using docker-compose health checks.

I think this is a better long term approach, and gets us able to run on arm machines, which maybe a cheaper alternative in the future.