### PR TITLE
Don't run trilogy tests on 7-0-stable and older

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -232,6 +232,8 @@ end
   activerecord    postgresql:test     postgresdb
   activerecord    sqlite3:test        default
 ).each_slice(3) do |dir, task, service|
+  next if RAILS_VERSION < Gem::Version.new("7.1.0.alpha") && task == "trilogy:test"
+
   steps_for(dir, task, service: service)
 
   next unless MAINLINE


### PR DESCRIPTION
I'm really unfamiliar with this repo, or how to test it.

But we're missing something as `trilogy` tests should be ran on stable branches: https://buildkite.com/rails/rails/builds/96088

@matthewd @eileencodes 