### PR TITLE
Pin PostgreSQL docker image version to `postgres:15.2-alpine`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       - "./mysql-initdb.d:/docker-entrypoint-initdb.d"
 
   postgres:
-    image: "${POSTGRES_IMAGE-postgres:alpine}"
+    image: "${POSTGRES_IMAGE-postgres:15.2-alpine}"
     environment:
       POSTGRES_HOST_AUTH_METHOD: "trust"
 


### PR DESCRIPTION
Rails CI 7-0-stable branch has been failing.
https://buildkite.com/rails/rails/builds/96360#01880ded-cecb-4a71-9e9f-35db4f5bbce7

```
Error:
ActiveRecord::TooManyOrTest#test_too_many_or:
ActiveRecord::StatementInvalid: PG::UndefinedFile: ERROR:  could not load library "/usr/local/lib/postgresql/llvmjit.so": Error relocating /usr/local/lib/postgresql/llvmjit.so: LLVMBuildGEP: symbol not found
```

PostgreSQL 15.3 has been released on May 11, 2023. https://www.postgresql.org/about/news/postgresql-153-148-1311-1215-and-1120-released-2637/

It also reproduces against main branch, until the root cause found, this commit pins the PostgreSQL docker image version to `postgres:15.2-alpine`.

- Steps to reproduce

```ruby
cd rails
git clone https://github.com/rails/buildkite-config .buildkite/
RUBY_IMAGE=ruby:3.2 docker-compose -f .buildkite/docker-compose.yml build base &&
  CI=1 POSTGRES_IMAGE=postgres:alpine docker-compose -f .buildkite/docker-compose.yml run postgresdb runner activerecord 'rake db:postgresql:rebuild test:postgresql'
```

- Current behavior without this change
```ruby
Error:
ActiveRecord::TooManyOrTest#test_too_many_or:
ActiveRecord::StatementInvalid: PG::UndefinedFile: ERROR:  could not load library "/usr/local/lib/postgresql/llvmjit.so": Error relocating /usr/local/lib/postgresql/llvmjit.so: LLVMBuildGEP: symbol not found

    /rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:788:in `exec_params'
    /rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:788:in `block (2 levels) in exec_no_cache'
    /rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:923:in `block in with_raw_connection'
    /rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
    /rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
    /rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
    /rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
    /rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:896:in `with_raw_connection'
    /rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:787:in `block in exec_no_cache'
    /rails/activesupport/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
    /rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:1020:in `log'
    /rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:786:in `exec_no_cache'
    /rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:766:in `execute_and_clear'
    /rails/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:63:in `exec_query'
    /rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:589:in `select'
    /rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:66:in `select_all'
    /rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:110:in `select_all'
    /rails/activerecord/lib/active_record/relation/calculations.rb:364:in `block in execute_simple_calculation'
    /rails/activerecord/lib/active_record/relation.rb:969:in `skip_query_cache_if_necessary'
    /rails/activerecord/lib/active_record/relation/calculations.rb:363:in `execute_simple_calculation'
    /rails/activerecord/lib/active_record/relation/calculations.rb:320:in `perform_calculation'
    /rails/activerecord/lib/active_record/relation/calculations.rb:178:in `calculate'
    /rails/activerecord/lib/active_record/relation/calculations.rb:51:in `count'
    /rails/activerecord/test/cases/relation/or_test.rb:190:in `test_too_many_or'

rails test rails/activerecord/test/cases/relation/or_test.rb:185
```