### PR TITLE
Use Debian 11 "bullseye" based Ruby Docker image

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -60,7 +60,11 @@ RUBIES = []
 SOFT_FAIL = []
 
 RUBY_MINORS.select { |v| v >= MIN_RUBY }.each do |v|
-  image = "ruby:#{v}"
+  if Gem::Version.new(v) >= Gem::Version.new("3.1")
+    image = "ruby:#{v}-bullseye"
+  else
+    image = "ruby:#{v}"
+  end
 
   if MAX_RUBY && v > MAX_RUBY && !(MAX_RUBY.approximate_recommendation === v)
     SOFT_FAIL << image


### PR DESCRIPTION
This pull request changes Ruby Docker images for 3.1 and 3.2 from Debian 12 "bookworm" based to Debian 11 "bullseye". Until we address the root cause of https://github.com/rails/rails/issues/48483

Refer to https://github.com/docker-library/ruby/pull/415