### PR TITLE
Revert "Use Debian 11 "bullseye" based Ruby Docker image"

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -60,11 +60,7 @@ RUBIES = []
 SOFT_FAIL = []
 
 RUBY_MINORS.select { |v| v >= MIN_RUBY }.each do |v|
-  if Gem::Version.new(v) >= Gem::Version.new("3.1")
-    image = "ruby:#{v}-bullseye"
-  else
-    image = "ruby:#{v}"
-  end
+  image = "ruby:#{v}"
 
   if MAX_RUBY && v > MAX_RUBY && !(MAX_RUBY.approximate_recommendation === v)
     SOFT_FAIL << image


### PR DESCRIPTION
Reverts rails/buildkite-config#47

Since https://github.com/rails/rails/pull/48493 has been merged to Rails main branch, we do not have to worry about `MD4` digest is not supported in OpenSSL 3.0 now. Let's use the latest Debian "bookworm" based Ruby images.