### PR TITLE
rubylang/ruby docker image uses Ubuntu jammy by default 

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -71,7 +71,7 @@ end
 
 ONE_RUBY = RUBIES.last || SOFT_FAIL.last
 
-MASTER_RUBY = "rubylang/ruby:master-nightly-focal"
+MASTER_RUBY = "rubylang/ruby:master-nightly-jammy"
 SOFT_FAIL << MASTER_RUBY
 
 # Adds yjit: onto the master ruby image string so we


### PR DESCRIPTION
This pull request updates to use Ubuntu jammy based rubylang/ruby docker image because it is by default https://github.com/ruby/ruby-docker-images/pull/43

Confirmed it works without failures or errors.

```ruby
$ git clone https://github.com/rails/rails.git
$ cd rails
$ git clone https://github.com/rails/buildkite-config .buildkite/
$ RUBY_IMAGE=rubylang/ruby:master-nightly-jammy docker-compose -f .buildkite/docker-compose.yml build base \
&& CI=1 docker-compose -f .buildkite/docker-compose.yml run default runner actionpack 'rake test'

Finished in 3.572241s, 1006.9311 runs/s, 4739.3225 assertions/s.
3597 runs, 16930 assertions, 0 failures, 0 errors, 0 skips
```

I recall this when I was investigating https://github.com/rails/rails/issues/48483 and https://github.com/rails/rails/pull/48493 and this issue does not reproduce against "rubylang/ruby:master-nightly-focal" image because this image is based on Ubuntu Focal that installs openssl 1.1 https://packages.ubuntu.com/focal/openssl . Ubuntu Jammy installs openssl 3.0 https://packages.ubuntu.com/jammy/openssl .