### PR TITLE
Install `npm` package to run `rake test:ujs` successfully

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ RUN echo "--- :ruby: Updating RubyGems and Bundler" \
         libxslt-dev \
         libyaml-dev \
         make \
+        npm \
         patch \
         unzip \
         xz-utils \


### PR DESCRIPTION
This commit addresses https://github.com/rails/rails/issues/48525

- Without this commit
```ruby
$ RUBY_IMAGE=ruby:3.2 docker-compose -f .buildkite/docker-compose.yml build base \
&& CI=1 docker-compose -f .buildkite/docker-compose.yml run -e PRE_STEPS -e RACK --rm actionview runner actionview 'rake test:ujs'
... snip ...
+++ actionview: rake test:ujs
ERROR: 127
$
```

- With this commit
```ruby
$ RUBY_IMAGE=ruby:3.2 docker-compose -f .buildkite/docker-compose.yml build base && CI=1 docker-compose -f .buildkite/docker-compose.yml run -e PRE_STEPS -e RACK --rm actionview runner actionview 'rake test:ujs' ... snip ...
+++ actionview: rake test:ujs

> @rails/ujs@7.1.0-alpha lint
> eslint app/javascript && eslint test/ujs/public/test

> @rails/ujs@7.1.0-alpha pretest
> rollup --config rollup.config.test.js

test/ujs/src/test.js → test/ujs/compiled/test.js... created test/ujs/compiled/test.js in 698ms

> @rails/ujs@7.1.0-alpha test
> karma start

20 06 2023 03:45:33.745:INFO [karma-server]: Karma v3.1.4 server started at http://0.0.0.0:9876/ 20 06 2023 03:45:33.748:INFO [launcher]: Launching browsers sl_chrome with concurrency unlimited 20 06 2023 03:45:33.753:INFO [launcher]: Starting browser chrome latest (Windows 10) on SauceLabs 20 06 2023 03:46:00.738:INFO [launcher.sauce]: chrome latest (Windows 10) session at https://saucelabs.com/tests/1a1f3e09f5f94d8dbcdc2a2eb572049d 20 06 2023 03:46:02.590:INFO [Chrome 114.0.0 (Windows 10.0.0)]: Connected on socket 01LDLgSQsZE1pohTAAAA with id 61941211 ................................................................................ .................................................. Chrome 114.0.0 (Windows 10.0.0): Executed 130 of 130 SUCCESS (17.381 secs / 17.118 secs) 20 06 2023 03:46:21.439:INFO [launcher.sauce]: Shutting down Sauce Connect $ echo $?
0
$
```

https://github.com/rails/rails/issues/48525 looks started since the base image for Ruby 3.2 changed
from Debian "bullseye" 11 based to Debian "bookworm" 12 based one. I have not found any souces why npm is not installed, though.