### PR TITLE
Install Node v18 LTS from NodeSource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "--- :ruby: Updating RubyGems and Bundler" \
     && echo "deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     # Node apt sources
     && curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add - \
-    && echo "deb http://deb.nodesource.com/node_16.x ${codename} main" > /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb http://deb.nodesource.com/node_18.x ${codename} main" > /etc/apt/sources.list.d/nodesource.list \
     # Yarn apt sources
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add - \
     && echo "deb http://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \


### PR DESCRIPTION
Fix https://github.com/rails/rails/issues/48525

This commit uses Node v18 LTS from NodeSource to install `npm` and use the latest LTS for Rails CI.

Since the Ruby`ruby:3.1` and `ruby:3.2` base image has changedfrom Debian "bullseye" 11 based to "bookworm" 12 based one, this causes `actionview: rake test:ujs ERROR: 127'.` This `ERROR: 127` is thrown when no `npm` program is found in the path.

We use NodeSource http://deb.nodesource.com/node_16.x to install the `nodejs` version 16 apt package , which also installs `npm` as described below.

https://deb.nodesource.com/node_16.x/dists/bookworm/main/binary-amd64/Packages
> Provides: nodejs-dev, nodejs-doc, nodejs-legacy, npm

There is another `nodejs` package provided by Debian. The `nodejs` version provided for Debian bullseye 11 is 12 , which is older than the 16 version provided by the NodeSource. As a result, `nodejs` from NodeSource will be installed on the Debian "bullseye" based image.

https://packages.debian.org/bullseye/nodejs
> Package: nodejs (12.22.12~dfsg-1~deb11u4) [security].

Debian "bookworm" 12 has been released which contains the `nodejs` package version 18, which is newer than version 16. Therefore, `nodejs` is installed from Debian on "bookworm" based images.

https://packages.debian.org/bookworm/nodejs
> Package: nodejs (18.13.0+dfsg1-1)

Unlike `nodejs` from NodeSource, the one from Debian does not include `npm`, so `npm` is missing, causing `ERROR: 127`. https://packages.debian.org/bookworm/amd64/nodejs/filelist