### PR TITLE
Allow retries for actionview test:ujs

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -292,7 +292,9 @@ steps_for("actioncable", "test:integration", service: "default") do |x|
   end
 end
 if REPO_ROOT.join("actionview/Rakefile").read.include?("task :ujs")
-  step_for("actionview", "test:ujs", service: "actionview")
+  step_for("actionview", "test:ujs", service: "actionview") do |x|
+    x["retry"] = { "automatic" => { "limit" => 3 } }
+  end
 end
 steps_for("activejob", "test:integration", service: "activejob") do |x|
   # Enable soft_fail until the problem in queue_classic is solved.


### PR DESCRIPTION
Similarly to actioncable integration, actionview ujs tests are executed in Saucelabs env that occasionally fails to start (e.g https://buildkite.com/rails/rails/builds/97407#0188e0b2-1402-4578-9214-6dfb0e26821f) so allowing retries for this seems to be reasonable.