### PR TITLE
Don't set commit when triggering rails-ci builds

### DIFF
--- a/buildkite-config-initial-pipeline.yml
+++ b/buildkite-config-initial-pipeline.yml
@@ -11,7 +11,6 @@ steps:
     label: ":pipeline: Run buildkite-config CI"
     build:
       message: "buildkite-config: ${BUILDKITE_MESSAGE}"
-      commit: "${BUILDKITE_COMMIT}"
       branch: "main"
       env:
         CONFIG_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"

--- a/buildkite-config-initial-pipeline.yml
+++ b/buildkite-config-initial-pipeline.yml
@@ -10,7 +10,7 @@ steps:
   - trigger: "rails-ci"
     label: ":pipeline: Run buildkite-config CI"
     build:
-      message: "buildkite-config: ${BUILDKITE_MESSAGE}"
+      message: "${BUILDKITE_REPO} ${BUILDKITE_MESSAGE} (${BUILDKITE_BRANCH})"
       branch: "main"
       env:
         CONFIG_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"

--- a/rails-initial-pipeline.yml
+++ b/rails-initial-pipeline.yml
@@ -19,7 +19,10 @@ steps:
           GIT_REPO="https://github.com/rails/buildkite-config"
         fi
 
-        git clone -b "$${CONFIG_BRANCH-main}" "$$GIT_REPO" .buildkite
+        GIT_BRANCH="$${CONFIG_BRANCH-main}"
+        GIT_BRANCH="$${GIT_BRANCH#*:}"
+
+        git clone -b "$$GIT_BRANCH" "$$GIT_REPO" .buildkite
 
         rm -rf .buildkite/.git
         sh -c "$$PIPELINE_COMMAND"


### PR DESCRIPTION
Follow up to #45, we don't want to setup `commit`.

From the docs [[ref](https://buildkite.com/docs/pipelines/trigger-step#trigger-step-attributes)]:

> commit    The commit hash for the build.
> Default: "HEAD"
> Example: "ca82a6d"

Example build failure when set using `${BUILDKITE_COMMIT}`:
https://buildkite.com/rails/rails-ci/builds/3

```
Git checkout failed as commit c16105efdbda6c0ca6cb00d0d38cb7ff8fe6f7b0 could not be found in branch main
```