### PR TITLE
Fix actiontext test:isolated on stable branches

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -243,6 +243,11 @@ end
     step_for(dir, task.sub(":test", ":isolated_test"), service: service) do |x|
       x["parallelism"] = 5 if REPO_ROOT.join("activerecord/Rakefile").read.include?("BUILDKITE_PARALLEL")
     end
+  elsif dir == "actiontext"
+    # added during 7.1 development on main
+    if REPO_ROOT.join("actiontext/Rakefile").read.include?("task :isolated")
+      step_for(dir, "#{task}:isolated", service: service)
+    end
   else
     step_for(dir, "#{task}:isolated", service: service)
   end


### PR DESCRIPTION
test:isolated was [enabled][1] for Action Text, but this has lead to failing builds on stable branches since the task only exists on the main branch

This fixes the issue by checking that the task exists before adding it to the pipeline

[1]: https://github.com/rails/buildkite-config/commit/b0431653b692006f64ab6a89e1e3b3101d778b67