### PR TITLE
Fix railties failing for tests using Webpacker

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -190,6 +190,7 @@ def step_for(subdirectory, rake_task, ruby: nil, service: "default", pre_steps: 
       {
         DOCKER_COMPOSE_PLUGIN => {
           "env" => [
+            "NODE_OPTIONS",
             "PRE_STEPS",
             "RACK"
           ],
@@ -303,6 +304,11 @@ steps_for("activejob", "test:integration", service: "activejob") do |x|
 end
 steps_for("railties", "test", service: "railties") do |x|
   x["parallelism"] = 12 if REPO_ROOT.join("railties/Rakefile").read.include?("BUILDKITE_PARALLEL")
+  if RAILS_VERSION < Gem::Version.new("7.0")
+    # OpenSSL 3 has now by default disabled some crypto functions used by
+    # Webpack 4 (which Webpacker is locked to)
+    x["env"]["NODE_OPTIONS"] = "--openssl-legacy-provider"
+  end
 end
 
 step_for("actionpack", "test", service: "default", pre_steps: ["bundle install"]) do |x|
@@ -314,6 +320,11 @@ step_for("railties", "test", service: "railties", pre_steps: ["bundle install"])
   x["parallelism"] = 12 if REPO_ROOT.join("railties/Rakefile").read.include?("BUILDKITE_PARALLEL")
   x["label"] += " [rack-2]"
   x["env"]["RACK"] = "~> 2.0"
+  if RAILS_VERSION < Gem::Version.new("7.0")
+    # OpenSSL 3 has now by default disabled some crypto functions used by
+    # Webpack 4 (which Webpacker is locked to)
+    x["env"]["NODE_OPTIONS"] = "--openssl-legacy-provider"
+  end
 end
 
 # Ugly hacks to just get the build passing for now


### PR DESCRIPTION
There were recently some changes to the base ruby Docker images that required us to [update][1] the version of Node.js we use in our images. In addition, the base image change brought OpenSSL 3.0 instead of the previous 1.x version. Since the change in base image, there have been failing railties tests for 6-1-stable:

```
** Execute webpacker:compile
Compiling...
Compilation failed:
node:internal/crypto/hash:71
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at module.exports (/rails/railties/test/isolation/assets/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/rails/railties/test/isolation/assets/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/rails/railties/test/isolation/assets/node_modules/webpack/lib/NormalModule.js:471:10)
    at /rails/railties/test/isolation/assets/node_modules/webpack/lib/NormalModule.js:503:5
    at /rails/railties/test/isolation/assets/node_modules/webpack/lib/NormalModule.js:358:12
    at /rails/railties/test/isolation/assets/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/rails/railties/test/isolation/assets/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at iterateNormalLoaders (/rails/railties/test/isolation/assets/node_modules/loader-runner/lib/LoaderRunner.js:221:10)
    at /rails/railties/test/isolation/assets/node_modules/loader-runner/lib/LoaderRunner.js:236:3
    at context.callback (/rails/railties/test/isolation/assets/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at /rails/railties/test/isolation/assets/node_modules/babel-loader/lib/index.js:44:71 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}
```

The issue is that OpenSSL has disabled some older crypto functions by default, and the version of Webpack/its dependencies required by Webpacker tries to use one of those older functions. We can re enable support for these old crypto functions by passing NODE_OPTIONS=--openssl-legacy-provider for Rails 6.1 (and newer versions will never have this problem as they do not use Webpacker)

[1]: https://github.com/rails/buildkite-config/commit/e7964c6d299951b80cc3a4041ad64d3ee7815e7a