### PR TITLE
Skip checking out rails/rails in test steps

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -197,6 +197,7 @@ def step_for(subdirectory, rake_task, ruby: nil, service: "default", pre_steps: 
           "pull" => service,
           "config" => ".buildkite/docker-compose.yml",
           "shell" => ["runner", subdirectory],
+          "skip-checkout" => true,
         },
       },
     ],
@@ -362,6 +363,14 @@ puts YAML.dump("steps" => [
             {
               DOCKER_COMPOSE_PLUGIN => {
                 "build" => "base",
+                "build-alias" => [
+                  "default",
+                  "mysqldb",
+                  "postgresdb",
+                  "railties",
+                  "activejob",
+                  "actionview",
+                ],
                 "config" => ".buildkite/docker-compose.yml",
                 "env" => [
                   "PRE_STEPS",


### PR DESCRIPTION
While it appears to be cached for some steps, the checkout takes 20-30 seconds when it doesn't cache. Since all of the tests run inside docker images the checkout is unnecessary so it can be disabled to save the time.

When enabling this setting, Buildkite gets more strict over how the Docker images are built. Because of this, we have to provide the other compose service names in the "build-alias" field.