### PR TITLE
Revert "Skip checking out rails/rails in test steps"

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -197,7 +197,6 @@ def step_for(subdirectory, rake_task, ruby: nil, service: "default", pre_steps: 
           "pull" => service,
           "config" => ".buildkite/docker-compose.yml",
           "shell" => ["runner", subdirectory],
-          "skip-checkout" => true,
         },
       },
     ],
@@ -363,14 +362,6 @@ puts YAML.dump("steps" => [
             {
               DOCKER_COMPOSE_PLUGIN => {
                 "build" => "base",
-                "build-alias" => [
-                  "default",
-                  "mysqldb",
-                  "postgresdb",
-                  "railties",
-                  "activejob",
-                  "actionview",
-                ],
                 "config" => ".buildkite/docker-compose.yml",
                 "env" => [
                   "PRE_STEPS",


### PR DESCRIPTION
Reverts rails/buildkite-config#57

I suspect this change (specifically the aliasing bit) is causing https://github.com/rails/rails/issues/48701

I believe I've also incidentally fixed the needless-git-checkout issue on the build agents themselves, so _in theory_ we can now safely revert this without losing the performance gain.