### PR TITLE
Move builds (and pipeline) into new "builder" queue

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -6,8 +6,18 @@ require "net/http"
 require "pathname"
 require "yaml"
 
-QUEUE = ENV["BUILDKITE_AGENT_META_DATA_QUEUE"] || "default"
-IMAGE_BASE = ENV["DOCKER_IMAGE"] || "973266071021.dkr.ecr.us-east-1.amazonaws.com/#{"#{QUEUE}-" unless QUEUE == 'default'}builds"
+STANDARD_QUEUES = [nil, "default", "builder"]
+
+# If the pipeline is running in a non-standard queue, default to
+# running everything in that queue.
+unless STANDARD_QUEUES.include?(ENV["BUILDKITE_AGENT_META_DATA_QUEUE"])
+  ENV["QUEUE"] ||= ENV["BUILDKITE_AGENT_META_DATA_QUEUE"]
+end
+
+BUILD_QUEUE = ENV["BUILD_QUEUE"] || ENV["QUEUE"] || "builder"
+RUN_QUEUE = ENV["RUN_QUEUE"] || ENV["QUEUE"] || "default"
+
+IMAGE_BASE = ENV["DOCKER_IMAGE"] || "973266071021.dkr.ecr.us-east-1.amazonaws.com/#{"#{BUILD_QUEUE}-" unless STANDARD_QUEUES.include?(BUILD_QUEUE)}builds"
 
 BASE_BRANCH = ([ENV["BUILDKITE_PULL_REQUEST_BASE_BRANCH"], ENV["BUILDKITE_BRANCH"], "main"] - [""]).first
 LOCAL_BRANCH = ([ENV["BUILDKITE_BRANCH"], "main"] - [""]).first
@@ -203,7 +213,7 @@ def step_for(subdirectory, rake_task, ruby: nil, service: "default", pre_steps: 
     "env" => env,
     "timeout_in_minutes" => timeout,
     "soft_fail" => SOFT_FAIL.include?(ruby),
-    "agents" => { "queue" => QUEUE },
+    "agents" => { "queue" => RUN_QUEUE },
     "artifact_paths" => ["test-reports/*/*.xml"],
     "retry" => { "automatic" => { "exit_status" => -1, "limit" => 2 } },
   }
@@ -393,7 +403,7 @@ puts YAML.dump("steps" => [
           },
           "timeout_in_minutes" => 15,
           "soft_fail" => SOFT_FAIL.include?(ruby),
-          "agents" => { "queue" => ENV["BUILD_QUEUE"] || QUEUE },
+          "agents" => { "queue" => BUILD_QUEUE },
         }
       end,
     ],

--- a/rails-initial-pipeline.yml
+++ b/rails-initial-pipeline.yml
@@ -50,6 +50,8 @@ steps:
                   - ".buildkite/*"
                   - ".buildkite/**/*"
           timeout_in_minutes: 5
+          agents:
+            queue: "$$BUILDKITE_AGENT_META_DATA_QUEUE"
       NESTED
       fi
       ([ -f .buildkite/.dockerignore ] && cp .buildkite/.dockerignore .dockerignore) || true
@@ -61,12 +63,19 @@ steps:
         docker run --rm
         -v "$$PWD":/app:ro -w /app
         -e CI
+        -e BUILDKITE_AGENT_META_DATA_QUEUE
         -e BUILDKITE_BRANCH
         -e BUILDKITE_BUILD_ID
         -e BUILDKITE_PULL_REQUEST
         -e BUILDKITE_PULL_REQUEST_BASE_BRANCH
         -e BUILDKITE_REBUILT_FROM_BUILD_ID
+        -e BUILD_QUEUE
+        -e DOCKER_IMAGE
+        -e RUN_QUEUE
+        -e QUEUE
         ruby:latest
         .buildkite/pipeline-generate |
         buildkite-agent pipeline upload
     timeout_in_minutes: 5
+    agents:
+      queue: "${QUEUE-builder}"


### PR DESCRIPTION
Buildkite have set up a dedicated agent pool for running image builds -- this change moves the relevant jobs to run on those agents.

The hope is that this will help builds to start faster, and also improve our ability to maintain some cached state between builds, as compared to the ephemeral runner instances.