### PR TITLE
Add buildkite-config diff tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .envrc
+/tmp

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
 gem "buildkit"
+gem "diffy"
+gem "rake"
+gem "autotest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,13 +3,24 @@ GEM
   specs:
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
+    autotest (5.0.0)
+      minitest-autotest (~> 1.0)
     buildkit (1.5.0)
       sawyer (>= 0.6)
+    diffy (3.4.2)
     faraday (2.7.7)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
+    minitest (5.19.0)
+    minitest-autotest (1.1.1)
+      minitest-server (~> 1.0)
+      path_expander (~> 1.0)
+    minitest-server (1.0.7)
+      minitest (~> 5.16)
+    path_expander (1.1.1)
     public_suffix (5.0.1)
+    rake (13.0.6)
     ruby2_keywords (0.0.5)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
@@ -19,7 +30,10 @@ PLATFORMS
   arm64-darwin-23
 
 DEPENDENCIES
+  autotest
   buildkit
+  diffy
+  rake
 
 BUNDLED WITH
    2.4.10

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative "lib/buildkite_config"
+
+require "minitest/test_task"
+Minitest::TestTask.create
+task default: [:test]
+
+task :diff => [:buildkite_config, :rails] do
+  diff = Buildkite::Config::Diff.compare
+  puts diff.to_s(:color)
+
+  annotate = Buildkite::Config::Annotate.new(diff)
+  annotate.perform
+end
+
+task :buildkite_config do
+  if !Dir.exist? "tmp/buildkite-config"
+    `git clone --depth=1 https://github.com/rails/buildkite-config tmp/buildkite-config`
+  else
+    `cd tmp/buildkite-config && git pull origin main`
+  end
+end
+
+task :rails do
+  if !Dir.exist? "tmp/rails"
+    `git clone --depth=1 https://github.com/rails/rails tmp/rails`
+  else
+    `cd tmp/rails && git pull origin main`
+  end
+end

--- a/buildkite-config-initial-pipeline.yml
+++ b/buildkite-config-initial-pipeline.yml
@@ -13,8 +13,31 @@ steps:
       Prefer a second opinion for any nontrivial change, especially outside `pipeline-generate`.
 
       - @matthewd
+  - command: |
+      git config --global --add safe.directory /workdir
+      bundle install
+      bundle exec rake test
+    key: self-test
+    plugins:
+      - docker#v5.8.0:
+          image: "ruby:latest"
+          propagate-environment: true
+  - command: |
+      git config --global --add safe.directory /workdir
+      bundle install
+      bundle exec rake diff
+    key: diff
+    depends_on: self-test
+    plugins:
+      - docker#v5.8.0:
+          image: "ruby:latest"
+          mount-buildkite-agent: true
+          propagate-environment: true
+          environment:
+            - "GITHUB_TOKEN"
   - trigger: "rails-ci"
     label: ":pipeline: Build Rails main with new config"
+    depends_on: diff
     build:
       message: "[${BUILDKITE_BRANCH}] ${BUILDKITE_MESSAGE}"
       branch: "main"
@@ -24,6 +47,7 @@ steps:
         BUILDKITE_CONFIG_TRIGGER: true # This variable can be used downstream to avoid things like "if branch==main do Y"
   - trigger: "rails-ci"
     label: ":pipeline: Build Rails 6-1-stable with new config"
+    depends_on: diff
     build:
       message: "[${BUILDKITE_BRANCH} / 6-1-stable] ${BUILDKITE_MESSAGE}"
       branch: "6-1-stable"

--- a/lib/buildkite_config.rb
+++ b/lib/buildkite_config.rb
@@ -1,0 +1,6 @@
+module Buildkite
+  module Config
+    autoload :Annotate, File.expand_path("buildkite_config/annotate", __dir__)
+    autoload :Diff, File.expand_path("buildkite_config/diff", __dir__)
+  end
+end

--- a/lib/buildkite_config/annotate.rb
+++ b/lib/buildkite_config/annotate.rb
@@ -1,0 +1,35 @@
+module Buildkite::Config
+  class Annotate
+    def initialize(diff)
+      @diff = diff
+    end
+
+    def perform
+      return if @diff.to_s.empty?
+
+      io = IO.popen("buildkite-agent annotate --style warning '#{plan}'")
+      output = io.read
+      io.close
+
+      raise output unless $?.success?
+
+      output
+    end
+
+    private
+      def plan
+        <<~PLAN
+          ### :writing_hand: buildkite-config/plan
+
+          <details>
+          <summary>Show Output</summary>
+
+          ```term
+          #{@diff.to_s(:color)}
+          ```
+
+          </details>
+        PLAN
+      end
+  end
+end

--- a/lib/buildkite_config/diff.rb
+++ b/lib/buildkite_config/diff.rb
@@ -1,0 +1,23 @@
+require "diffy"
+
+module Buildkite::Config
+  module Diff
+    def self.compare
+      head = generated_pipeline(".")
+      main = generated_pipeline("tmp/buildkite-config")
+      Diffy::Diff.new(main, head, context: 4)
+    end
+
+    def self.generated_pipeline(repo)
+      io = IO.popen "ruby #{repo}/pipeline-generate tmp/rails"
+
+      output = io.read
+      io.close
+
+      raise output unless $?.success?
+
+      output
+    end
+  end
+end
+

--- a/pipeline-generate
+++ b/pipeline-generate
@@ -236,7 +236,6 @@ end
   activemodel     test                default
   activesupport   test                default
   actionview      test                default
-  actiontext      test                default
   activejob       test                default
   activerecord    mysql2:test         mysqldb
   activerecord    trilogy:test        mysqldb

--- a/test/buildkite_config/test_annotate.rb
+++ b/test/buildkite_config/test_annotate.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "buildkite_config"
+require "minitest/autorun"
+
+class TestAnnotate < Minitest::Test
+  def test_the_truth
+    assert true
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"


### PR DESCRIPTION
Adds the diff of generated pipeline to the buildkite annotations:
[[Example](https://buildkite.com/zzak/buildkite-config/builds/163)]

<img width="842" alt="Screenshot 2023-08-25 at 20 06 48" src="https://github.com/rails/buildkite-config/assets/277819/baeafe60-4f79-4483-8799-d32b6474c6ba">

---

This step occurs _after_ the approval prompt since we are evaling user input directly to the ruby interpreter. It doesn't fail or anything if there are changes.

My goal is to use this diff as a baseline for refactoring, to avoid accidental breakage to the generated pipeline unintentionally.