### PR TITLE
Add Ruby 3.3

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -34,7 +34,7 @@ ARTIFACTS_PLUGIN = "artifacts#v1.2.0"
 REPO_ROOT = Pathname.new(ARGV.shift || File.expand_path("../..", __FILE__))
 
 REPO_ROOT.join("rails.gemspec").read =~ /required_ruby_version[^0-9]+([0-9]+\.[0-9]+)/
-RUBY_MINORS = %w(2.4 2.5 2.6 2.7 3.0 3.1 3.2).map { |v| Gem::Version.new(v) }
+RUBY_MINORS = %w(2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3).map { |v| Gem::Version.new(v) }
 MIN_RUBY = Gem::Version.new($1 || "2.0")
 
 RAILS_VERSION = Gem::Version.new(File.read(REPO_ROOT.join("RAILS_VERSION")))


### PR DESCRIPTION
Ruby 3.3 has been released and `ruby:3.3` Docker image is available.

```
$ docker run --rm -t ruby:3.3 ruby -v
... snip ...
Digest: sha256:30ff8d6bd91710608014613c9b1820ced34f54af90d4ea20feb67cb2cc1e703b
Status: Downloaded newer image for ruby:3.3
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-linux]
$
```

Refer to:
https://github.com/docker-library/ruby/issues/434
https://github.com/docker-library/official-images/pull/15959