### PR TITLE
Fix missing npm by migrating to new nodesource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN echo "--- :ruby: Updating RubyGems and Bundler" \
     #  specific dependencies for the rails build
     && apt-get install -y --no-install-recommends \
         postgresql-client default-mysql-client sqlite3 \
-        git nodejs yarn lsof \
+        git nodejs=18.19.0-1nodesource1 yarn lsof \
         ffmpeg mupdf mupdf-tools poppler-utils \
     # await (for waiting on dependent services)
     && curl -fLsS -o /tmp/await-linux-amd64 https://github.com/betalo-sweden/await/releases/download/v0.4.0/await-linux-amd64 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,14 @@ RUN echo "--- :ruby: Updating RubyGems and Bundler" \
         && apt-get install -y --no-install-recommends \
             gnupg curl; \
     fi \
+    # Debian 12 (bookworm) has this directory by default, but older Debian does not
+    && mkdir -p /etc/apt/keyrings \
     # Postgres apt sources
     && curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add - \
     && echo "deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     # Node apt sources
-    && curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add - \
-    && echo "deb http://deb.nodesource.com/node_18.x ${codename} main" > /etc/apt/sources.list.d/nodesource.list \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
     # Yarn apt sources
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add - \
     && echo "deb http://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \


### PR DESCRIPTION
Fixes rails/rails#50524

The old nodesource repository is no longer being updated, which is why the debian node version is now higher than nodesource's (and debian's nodejs package does not install npm, hence the missing npm issue).

Followed the instructions here to setup the new repository: https://github.com/nodesource/distributions/wiki/How-to-migrate-to-the-new-repository