### PR TITLE
Make 'yarn build' from actionview optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -140,7 +140,9 @@ ADD . ./
 RUN mv -f tmp/Gemfile.lock.updated Gemfile.lock \
     && if [ -f package.json ]; then \
         echo "--- :javascript: Building JavaScript package" \
-        && (cd actionview && yarn build) \
+        && if [ -f actionview/package.json ]; then \
+            (cd actionview && yarn build); \
+        fi \
         && if [ -f railties/test/isolation/assets/package.json ]; then \
             (cd railties/test/isolation/assets && yarn install); \
         fi \


### PR DESCRIPTION
See rails/rails#50535

This makes running `yarn build` from the 'actionview' directory optional, as the machinery for building and testing rails-ujs will be removed.