### PR TITLE
Remove guide testing for Ruby 2.7 and Ruby 3.0

### DIFF
--- a/pipeline-generate
+++ b/pipeline-generate
@@ -366,9 +366,9 @@ end
 STEPS.select { |s| s["label"] =~ /^guides/  }.each do |s|
   s["soft_fail"] = true
 end
-if RAILS_VERSION < Gem::Version.new("7.x") && RAILS_VERSION >= Gem::Version.new("6.1")
-  STEPS.delete_if { |s| s["label"] == "guides (2.7)" || s["label"] == "guides (3.0)" }
-end
+# Now that main requires Ruby 3.1, any bug report template referencing main
+# fails on Ruby < 3.1
+STEPS.delete_if { |s| s["label"] == "guides (2.7)" || s["label"] == "guides (3.0)" }
 STEPS.delete_if { |s| s["label"] =~ /^guides/ } if RAILS_VERSION < Gem::Version.new("7.0")
 
 ###


### PR DESCRIPTION
Now that main has been updated to only support Ruby 3.1+, the guides tests on 7-0-stable and 7-1-stable are failing for Ruby 2.7 and 3.0 (since half the bug report templates are for the main branch). This commit removes the steps to test guides on these Ruby versions so that there are no longer failing steps on stable branches.

Alternatively, we could backport the bug report template refactors that removed the template pointing at main in favor of a comment inside the gem template.