### PR TITLE
Move Ruby master and YJIT to a nightly build pipeline

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,16 +6,19 @@ require "minitest/test_task"
 Minitest::TestTask.create
 task default: [:test]
 
-task :print_diff => [:buildkite_config, :rails] do
-  diff = Buildkite::Config::Diff.compare
-  puts diff.to_s()
+task :print_diff, [:nightly] => [:buildkite_config, :rails] do |_, args|
+  args.with_defaults(nightly: false)
+  diff = Buildkite::Config::Diff.compare(nightly: args[:nightly])
+  puts diff.to_s(:color)
 end
 
-task :diff => [:buildkite_config, :rails] do
-  diff = Buildkite::Config::Diff.compare
+task :diff, [:nightly] => [:buildkite_config, :rails] do |_, args|
+  args.with_defaults(nightly: false)
+
+  diff = Buildkite::Config::Diff.compare(nightly: args[:nightly])
   puts diff.to_s(:color)
 
-  annotate = Buildkite::Config::Annotate.new(diff)
+  annotate = Buildkite::Config::Annotate.new(diff, nightly: args[:nightly])
   annotate.perform
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,11 @@ require "minitest/test_task"
 Minitest::TestTask.create
 task default: [:test]
 
+task :print_diff => [:buildkite_config, :rails] do
+  diff = Buildkite::Config::Diff.compare
+  puts diff.to_s()
+end
+
 task :diff => [:buildkite_config, :rails] do
   diff = Buildkite::Config::Diff.compare
   puts diff.to_s(:color)

--- a/buildkite-config-initial-pipeline.yml
+++ b/buildkite-config-initial-pipeline.yml
@@ -26,6 +26,7 @@ steps:
       git config --global --add safe.directory /workdir
       bundle install
       bundle exec rake diff
+      bundle exec rake diff[true]
     key: diff
     depends_on: self-test
     plugins:
@@ -47,6 +48,26 @@ steps:
         BUILDKITE_CONFIG_TRIGGER: true # This variable can be used downstream to avoid things like "if branch==main do Y"
   - trigger: "rails-ci"
     label: ":pipeline: Build Rails 6-1-stable with new config"
+    depends_on: diff
+    build:
+      message: "[${BUILDKITE_BRANCH} / 6-1-stable] ${BUILDKITE_MESSAGE}"
+      branch: "6-1-stable"
+      env:
+        CONFIG_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
+        CONFIG_BRANCH: "${BUILDKITE_BRANCH}"
+        BUILDKITE_CONFIG_TRIGGER: true # This variable can be used downstream to avoid things like "if branch==main do Y"
+  - trigger: "rails-ci-nightly"
+    label: ":pipeline: Build Rails main with new nightly config"
+    depends_on: diff
+    build:
+      message: "[${BUILDKITE_BRANCH}] ${BUILDKITE_MESSAGE}"
+      branch: "main"
+      env:
+        CONFIG_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
+        CONFIG_BRANCH: "${BUILDKITE_BRANCH}"
+        BUILDKITE_CONFIG_TRIGGER: true # This variable can be used downstream to avoid things like "if branch==main do Y"
+  - trigger: "rails-ci-nightly"
+    label: ":pipeline: Build Rails 6-1-stable with new nightly config"
     depends_on: diff
     build:
       message: "[${BUILDKITE_BRANCH} / 6-1-stable] ${BUILDKITE_MESSAGE}"

--- a/lib/buildkite_config/annotate.rb
+++ b/lib/buildkite_config/annotate.rb
@@ -8,7 +8,9 @@ module Buildkite::Config
     def perform
       return if @diff.to_s.empty?
 
-      io = IO.popen("buildkite-agent annotate --style warning '#{plan}'")
+      context = "config#{"-nightly" if @nightly}"
+
+      io = IO.popen("buildkite-agent annotate --style warning --context #{context} '#{plan}'")
       output = io.read
       io.close
 

--- a/lib/buildkite_config/annotate.rb
+++ b/lib/buildkite_config/annotate.rb
@@ -1,7 +1,8 @@
 module Buildkite::Config
   class Annotate
-    def initialize(diff)
+    def initialize(diff, nightly: false)
       @diff = diff
+      @nightly = nightly
     end
 
     def perform
@@ -19,7 +20,7 @@ module Buildkite::Config
     private
       def plan
         <<~PLAN
-          ### :writing_hand: buildkite-config/plan
+          ### :writing_hand: buildkite-config#{"-nightly" if @nightly}/plan
 
           <details>
           <summary>Show Output</summary>

--- a/lib/buildkite_config/diff.rb
+++ b/lib/buildkite_config/diff.rb
@@ -2,22 +2,31 @@ require "diffy"
 
 module Buildkite::Config
   module Diff
-    def self.compare
-      head = generated_pipeline(".")
-      main = generated_pipeline("tmp/buildkite-config")
+    def self.compare(nightly: false)
+      head = generated_pipeline(".", nightly: nightly)
+      main = generated_pipeline("tmp/buildkite-config", nightly: nightly)
       Diffy::Diff.new(main, head, context: 4)
     end
 
-    def self.generated_pipeline(repo)
-      io = IO.popen "ruby #{repo}/pipeline-generate tmp/rails"
+    def self.generated_pipeline(repo, nightly: false)
+      command = if nightly
+        "pipeline-generate-nightly"
+      else
+        "pipeline-generate"
+      end
+
+      io = IO.popen "ruby #{repo}/#{command} tmp/rails"
 
       output = io.read
       io.close
 
-      raise output unless $?.success?
+      unless $?.success?
+        $stderr.puts "Failed to generate pipeline for #{repo}"
+
+        return ""
+      end
 
       output
     end
   end
 end
-

--- a/pipeline-generate-nightly
+++ b/pipeline-generate-nightly
@@ -69,6 +69,8 @@ SOFT_FAIL.reverse!
 # Run soft-failing Ruby steps last.
 RUBIES.concat SOFT_FAIL
 
+ONE_RUBY = RUBIES.last
+
 STEPS = []
 
 def image_name_for(ruby, suffix = BUILD_ID, short: false)
@@ -125,7 +127,7 @@ def step_for(subdirectory, rake_task, ruby: nil, service: "default", pre_steps: 
   end
 
   env = {
-    "IMAGE_NAME" => image_name_for(ruby),
+    "IMAGE_NAME" => image_name_for(ruby || ONE_RUBY),
   }
 
   # If we have YJIT_RUBY set the environment variable
@@ -145,7 +147,7 @@ def step_for(subdirectory, rake_task, ruby: nil, service: "default", pre_steps: 
     if rake_task.include?("isolated")
       "isolated"
     else
-      ruby
+      ruby || ONE_RUBY
     end
 
   if RAILS_VERSION < Gem::Version.new("5.x")
@@ -160,7 +162,7 @@ def step_for(subdirectory, rake_task, ruby: nil, service: "default", pre_steps: 
 
   hash = {
     "label" => label,
-    "depends_on" => "docker-image-#{ruby_image(ruby).gsub(/\W/, "-")}",
+    "depends_on" => "docker-image-#{ruby_image(ruby || ONE_RUBY).gsub(/\W/, "-")}",
     "command" => command,
     "group" => group,
     "plugins" => [

--- a/pipeline-generate-nightly
+++ b/pipeline-generate-nightly
@@ -34,8 +34,6 @@ ARTIFACTS_PLUGIN = "artifacts#v1.2.0"
 REPO_ROOT = Pathname.new(ARGV.shift || File.expand_path("../..", __FILE__))
 
 REPO_ROOT.join("rails.gemspec").read =~ /required_ruby_version[^0-9]+([0-9]+\.[0-9]+)/
-RUBY_MINORS = %w(2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3).map { |v| Gem::Version.new(v) }
-MIN_RUBY = Gem::Version.new($1 || "2.0")
 
 RAILS_VERSION = Gem::Version.new(File.read(REPO_ROOT.join("RAILS_VERSION")))
 BUNDLER =
@@ -53,36 +51,19 @@ RUBYGEMS =
     "3.2.9"
   end
 
-MAX_RUBY =
-  case RAILS_VERSION
-  when Gem::Requirement.new("< 5.1")
-    Gem::Version.new("2.4")
-  when Gem::Requirement.new("< 5.2")
-    Gem::Version.new("2.5")
-  when Gem::Requirement.new("< 6.0")
-    Gem::Version.new("2.6")
-  when Gem::Requirement.new("< 6.1")
-    Gem::Version.new("2.7")
-  end
-
-
 RUBIES = []
 SOFT_FAIL = []
 
-RUBY_MINORS.select { |v| v >= MIN_RUBY }.each do |v|
-  image = "ruby:#{v}"
+MASTER_RUBY = "rubylang/ruby:master-nightly-jammy"
+SOFT_FAIL << MASTER_RUBY
 
-  if MAX_RUBY && v > MAX_RUBY && !(MAX_RUBY.approximate_recommendation === v)
-    SOFT_FAIL << image
-  else
-    RUBIES << image
-  end
-end
-
-ONE_RUBY = RUBIES.last || SOFT_FAIL.last
+# Adds yjit: onto the master ruby image string so we
+# know when to turn on YJIT via the environment variable.
+# Same as master ruby, we want this to soft fail.
+YJIT_RUBY = "yjit:#{MASTER_RUBY}"
+SOFT_FAIL << YJIT_RUBY
 
 # Run steps for newer Rubies first.
-RUBIES.reverse!
 SOFT_FAIL.reverse!
 
 # Run soft-failing Ruby steps last.
@@ -110,12 +91,22 @@ end
 # via an ENV var. This needs to remove the `yjit:` added onto the
 # front because otherwise it's not a valid image.
 def ruby_image(ruby)
-  ruby
+  if ruby == YJIT_RUBY
+    ruby.sub("yjit:", "")
+  else
+    ruby
+  end
 end
 
 # A shortened version of the name for the Buildkite label.
 def short_ruby(ruby)
-  ruby.sub(/^ruby:|:latest$/, "")
+  if ruby == MASTER_RUBY
+    "master"
+  elsif ruby == YJIT_RUBY
+    "yjit"
+  else
+    ruby.sub(/^ruby:|:latest$/, "")
+  end
 end
 
 def step_for(subdirectory, rake_task, ruby: nil, service: "default", pre_steps: [])
@@ -134,8 +125,14 @@ def step_for(subdirectory, rake_task, ruby: nil, service: "default", pre_steps: 
   end
 
   env = {
-    "IMAGE_NAME" => image_name_for(ruby || ONE_RUBY),
+    "IMAGE_NAME" => image_name_for(ruby),
   }
+
+  # If we have YJIT_RUBY set the environment variable
+  # to turn it on.
+  if ruby == YJIT_RUBY
+    env["RUBY_YJIT_ENABLE"] = "1"
+  end
 
   if !pre_steps.empty?
     env["PRE_STEPS"] = pre_steps.join(" && ")
@@ -148,7 +145,7 @@ def step_for(subdirectory, rake_task, ruby: nil, service: "default", pre_steps: 
     if rake_task.include?("isolated")
       "isolated"
     else
-      ruby || ONE_RUBY
+      ruby
     end
 
   if RAILS_VERSION < Gem::Version.new("5.x")
@@ -163,7 +160,7 @@ def step_for(subdirectory, rake_task, ruby: nil, service: "default", pre_steps: 
 
   hash = {
     "label" => label,
-    "depends_on" => "docker-image-#{ruby_image(ruby || ONE_RUBY).gsub(/\W/, "-")}",
+    "depends_on" => "docker-image-#{ruby_image(ruby).gsub(/\W/, "-")}",
     "command" => command,
     "group" => group,
     "plugins" => [
@@ -365,7 +362,7 @@ puts YAML.dump("steps" => [
   {
     "group" => "build",
     "steps" => [
-      *(RUBIES).map do |ruby|
+      *(RUBIES - [YJIT_RUBY]).map do |ruby|
         {
           "label" => ":docker: #{ruby}",
           "key" => "docker-image-#{ruby.gsub(/\W/, "-")}",

--- a/rails-nightly-initial-pipeline.yml
+++ b/rails-nightly-initial-pipeline.yml
@@ -1,0 +1,81 @@
+# This file is never read -- it's just a copy of the pipeline's
+# configuration in the Buildkite UI.
+
+steps:
+  - name: ":pipeline:"
+    command: |
+      PATH=/bin:/usr/bin
+      set -e
+      treesha="$$(git ls-tree -d HEAD .buildkite | awk '{print $$3}')"
+      if [ -z "$${treesha}" ]; then
+        echo "+++ No .buildkite/; using fallback repository"
+        rm -rf .buildkite
+
+        if [ -n "$$CONFIG_REPO" ]; then
+          GIT_REPO="$$CONFIG_REPO"
+        elif [ -n "$$CONFIG_FORK" ]; then
+          GIT_REPO="https://github.com/$$CONFIG_FORK/buildkite-config"
+        else
+          GIT_REPO="https://github.com/rails/buildkite-config"
+        fi
+
+        GIT_BRANCH="$${CONFIG_BRANCH-main}"
+        GIT_BRANCH="$${GIT_BRANCH#*:}"
+
+        git clone -b "$$GIT_BRANCH" "$$GIT_REPO" .buildkite
+
+        rm -rf .buildkite/.git
+        sh -c "$$PIPELINE_COMMAND"
+      elif [ "$${#treesha}" -lt 40 ]; then
+        echo "Short SHA for .buildkite/"
+        exit 1
+      elif curl -s -S "https://gist.githubusercontent.com/matthewd/3f98bcc9957c8ddf2204a390bf3a6cdd/raw/list" | grep -a -F -x "$${treesha}"; then
+        echo "+++ Known tree; generating pipeline"
+        echo ".buildkite/ tree is $${treesha}"
+        sh -c "$$PIPELINE_COMMAND"
+      else
+        echo "+++ Unknown tree; requesting approval"
+        echo ".buildkite/ tree is $${treesha}"
+        buildkite-agent pipeline upload <<'NESTED'
+      steps:
+        - block: "Review Build Script"
+          prompt: |
+            This commit uses new build configuration. Please review the changes in .buildkite/ carefully before unblocking.
+        - name: ":pipeline:"
+          command: >-
+            $$PIPELINE_COMMAND
+          plugins:
+            - artifacts#v1.2.0:
+                download:
+                  - ".buildkite/*"
+                  - ".buildkite/**/*"
+          timeout_in_minutes: 5
+          agents:
+            queue: "$$BUILDKITE_AGENT_META_DATA_QUEUE"
+      NESTED
+      fi
+      ([ -f .buildkite/.dockerignore ] && cp .buildkite/.dockerignore .dockerignore) || true
+    plugins:
+      - artifacts#v1.2.0:
+          upload: [".buildkite/**/*", ".dockerignore"]
+    env:
+      PIPELINE_COMMAND: >-
+        docker run --rm
+        -v "$$PWD":/app:ro -w /app
+        -e CI
+        -e BUILDKITE_AGENT_META_DATA_QUEUE
+        -e BUILDKITE_BRANCH
+        -e BUILDKITE_BUILD_ID
+        -e BUILDKITE_PULL_REQUEST
+        -e BUILDKITE_PULL_REQUEST_BASE_BRANCH
+        -e BUILDKITE_REBUILT_FROM_BUILD_ID
+        -e BUILD_QUEUE
+        -e DOCKER_IMAGE
+        -e RUN_QUEUE
+        -e QUEUE
+        ruby:latest
+        .buildkite/pipeline-generate-nightly |
+        buildkite-agent pipeline upload
+    timeout_in_minutes: 5
+    agents:
+      queue: "${QUEUE-builder}"

--- a/update-initial-pipelines
+++ b/update-initial-pipelines
@@ -25,9 +25,23 @@ update_pipeline("rails", rails_init)
 
 puts "\n" * 2; puts "#####"; puts "\n" * 2
 
+# Update rails/rails-nightly
+puts "Updating rails/rails-nightly..."
+rails_nightly_init = File.read("rails-nightly-initial-pipeline.yml")
+update_pipeline("rails-nightly", rails_nightly_init)
+
+puts "\n" * 2; puts "#####"; puts "\n" * 2
+
 # Update rails/rails-ci
 puts "Updating rails/rails-ci..."
 update_pipeline("rails-ci", rails_init)
+
+puts "\n" * 2; puts "#####"; puts "\n" * 2
+
+# Update rails/rails-ci-nightly
+puts "Updating rails/rails-ci-nightly..."
+rails_nightly_init = File.read("rails-nightly-initial-pipeline.yml")
+update_pipeline("rails-ci-nightly", rails_nightly_init)
 
 puts "\n" * 2; puts "#####"; puts "\n" * 2
 


### PR DESCRIPTION
All those steps takes a lot of time and we don't have a lot of agents. Since we don't need to run those every single change, remove them from the main pipeline.