### PR TITLE
Fix diff command by running pipeline-generate from inside the checkout

### DIFF
--- a/lib/buildkite/config/build_context.rb
+++ b/lib/buildkite/config/build_context.rb
@@ -23,7 +23,7 @@ module Buildkite::Config
       if ci? && %w[rails-ci rails-ci-nightly rails-sandbox zzak/rails rails rails-nightly].include?(pipeline_slug)
         Pathname.pwd
       else
-        Pathname.pwd.join("tmp/rails")
+        Pathname.pwd.join("../rails")
       end
     end
 

--- a/lib/buildkite/config/diff.rb
+++ b/lib/buildkite/config/diff.rb
@@ -11,24 +11,23 @@ module Buildkite::Config
     end
 
     def self.generated_pipeline(repo, nightly: false)
-      command = ["ruby", "#{repo}/pipeline-generate"]
+      command = ["ruby", "pipeline-generate"]
 
       command.push("--nightly") if nightly
 
-      command.push("tmp/rails")
+      Dir.chdir(repo) do
+        io = IO.popen(command)
+        output = io.read
+        io.close
 
-      io = IO.popen(command)
+        unless $?.success?
+          $stderr.puts "Failed to generate pipeline for #{repo}"
 
-      output = io.read
-      io.close
+          return ""
+        end
 
-      unless $?.success?
-        $stderr.puts "Failed to generate pipeline for #{repo}"
-
-        return ""
+        output
       end
-
-      output
     end
   end
 end

--- a/test/buildkite_config/test_build_context.rb
+++ b/test/buildkite_config/test_build_context.rb
@@ -73,7 +73,7 @@ class TestBuildContext < TestCase
   def test_rails_root_not_ci
     sub = create_build_context
     sub.stub(:ci?, false) do
-      assert_equal Pathname.new(Dir.pwd) + "tmp/rails", sub.rails_root
+      assert_equal Pathname.new(Dir.pwd) + "../rails", sub.rails_root
     end
   end
 
@@ -81,7 +81,7 @@ class TestBuildContext < TestCase
     sub = create_build_context
     sub.stub(:ci?, true) do
       sub.stub(:pipeline_slug, "not-rails-ci") do
-        assert_equal Pathname.new(Dir.pwd) + "tmp/rails", sub.rails_root
+        assert_equal Pathname.new(Dir.pwd) + "../rails", sub.rails_root
       end
     end
   end


### PR DESCRIPTION
This is an alternative to configuring the pipeline path directly in bkb, which required a change originally proposed in Gusto/buildkite-builder#109 and fixed in Gusto/buildkite-builder#110 (available in v4.8.0).

I've also removed the "tmp/rails" argument since `pipeline-generate` actually doesn't use that and we determine the path to the rails/rails checkout based on one of two scenarios:

* We're running in CI on a rails-ci pipeline (either a sandbox, fork, or nightly build): The rails checkout is in the `$PWD`.
* Or we're running somewhere like the buildkite-config pipeline or locally and the checkout is in a tmp directory.

NOTE: This change to build_context is required and can't actually demonstrate the diff is working until it's available upstream (without drastic hacking):

```diff
-        Pathname.pwd.join("tmp/rails")
+        Pathname.pwd.join("../rails")
```

It does work locally!