### PR TITLE
Don't pull compose images

### DIFF
--- a/lib/buildkite/config/rake_command.rb
+++ b/lib/buildkite/config/rake_command.rb
@@ -59,7 +59,6 @@ module Buildkite::Config
           plugin :docker_compose, {
             "env" => %w[PRE_STEPS RACK],
             "run" => service,
-            "pull" => service,
             "config" => ".buildkite/docker-compose.yml",
             "shell" => ["runner", dir],
           }

--- a/test/buildkite_config/test_rake_command.rb
+++ b/test/buildkite_config/test_rake_command.rb
@@ -70,7 +70,6 @@ class TestRakeCommand < TestCase
           { "docker-compose#v1.0" =>
             { "env" => ["PRE_STEPS", "RACK"],
             "run" => "default",
-            "pull" => "default",
             "config" => ".buildkite/docker-compose.yml",
             "shell" => ["runner", "test"] } }] }] }
     assert_equal expected, pipeline.to_h
@@ -100,7 +99,6 @@ class TestRakeCommand < TestCase
           { "docker-compose#v1.0" =>
             { "env" => ["PRE_STEPS", "RACK"],
             "run" => "default",
-            "pull" => "default",
             "config" => ".buildkite/docker-compose.yml",
             "shell" => ["runner", "activerecord"] } }] }] }
     assert_equal expected, pipeline.to_h
@@ -131,7 +129,6 @@ class TestRakeCommand < TestCase
           { "docker-compose#v1.0" =>
             { "env" => ["PRE_STEPS", "RACK"],
             "run" => "default",
-            "pull" => "default",
             "config" => ".buildkite/docker-compose.yml",
             "shell" => ["runner", "first"] } }] },
       { "label" => "second all (3.2)",
@@ -147,7 +144,6 @@ class TestRakeCommand < TestCase
           { "docker-compose#v1.0" =>
             { "env" => ["PRE_STEPS", "RACK"],
             "run" => "default",
-            "pull" => "default",
             "config" => ".buildkite/docker-compose.yml",
             "shell" => ["runner", "second"] } }] }] }
     assert_equal expected, pipeline.to_h
@@ -177,7 +173,6 @@ class TestRakeCommand < TestCase
           { "docker-compose#v1.0" =>
             { "env" => ["PRE_STEPS", "RACK"],
             "run" => "myservice",
-            "pull" => "myservice",
             "config" => ".buildkite/docker-compose.yml",
             "shell" => ["runner", "subdirectory"] } }] }] }
     assert_equal expected, pipeline.to_h
@@ -208,7 +203,6 @@ class TestRakeCommand < TestCase
           { "docker-compose#v1.0" =>
             { "env" => ["PRE_STEPS", "RACK"],
             "run" => "default",
-            "pull" => "default",
             "config" => ".buildkite/docker-compose.yml",
             "shell" => ["runner", ""] } }] }] }
     assert_equal expected, pipeline.to_h
@@ -240,7 +234,6 @@ class TestRakeCommand < TestCase
           { "docker-compose#v1.0" =>
             { "env" => ["PRE_STEPS", "RACK"],
             "run" => "default",
-            "pull" => "default",
             "config" => ".buildkite/docker-compose.yml",
             "shell" => ["runner", ""] } }] }] }
     assert_equal expected, pipeline.to_h
@@ -273,7 +266,6 @@ class TestRakeCommand < TestCase
           { "docker-compose#v1.0" =>
             { "env" => ["PRE_STEPS", "RACK"],
             "run" => "default",
-            "pull" => "default",
             "config" => ".buildkite/docker-compose.yml",
             "shell" => ["runner", ""] } }] }] }
     assert_equal expected, pipeline.to_h
@@ -306,7 +298,6 @@ class TestRakeCommand < TestCase
           { "docker-compose#v1.0" =>
             { "env" => ["PRE_STEPS", "RACK"],
             "run" => "default",
-            "pull" => "default",
             "config" => ".buildkite/docker-compose.yml",
             "shell" => ["runner", ""] } }] }] }
     assert_equal expected, pipeline.to_h
@@ -342,7 +333,6 @@ class TestRakeCommand < TestCase
           { "docker-compose#v1.0" =>
             { "env" => ["PRE_STEPS", "RACK"],
             "run" => "default",
-            "pull" => "default",
             "config" => ".buildkite/docker-compose.yml",
             "shell" => ["runner", ""] } }] }] }
     assert_equal expected, pipeline.to_h
@@ -375,7 +365,6 @@ class TestRakeCommand < TestCase
           { "docker-compose#v1.0" =>
             { "env" => ["PRE_STEPS", "RACK"],
             "run" => "default",
-            "pull" => "default",
             "config" => ".buildkite/docker-compose.yml",
             "shell" => ["runner", ""] } }] }] }
     assert_equal expected, pipeline.to_h
@@ -409,7 +398,6 @@ class TestRakeCommand < TestCase
           { "docker-compose#v1.0" =>
             { "env" => ["PRE_STEPS", "RACK"],
             "run" => "default",
-            "pull" => "default",
             "config" => ".buildkite/docker-compose.yml",
             "shell" => ["runner", ""] } }] }] }
     assert_equal expected, pipeline.to_h
@@ -442,7 +430,6 @@ class TestRakeCommand < TestCase
           { "docker-compose#v1.0" =>
             { "env" => ["PRE_STEPS", "RACK"],
             "run" => "default",
-            "pull" => "default",
             "config" => ".buildkite/docker-compose.yml",
             "shell" => ["runner", ""] } }] }] }
     assert_equal expected, pipeline.to_h
@@ -475,7 +462,6 @@ class TestRakeCommand < TestCase
           { "docker-compose#v1.0" =>
             { "env" => ["PRE_STEPS", "RACK"],
             "run" => "default",
-            "pull" => "default",
             "config" => ".buildkite/docker-compose.yml",
             "shell" => ["runner", "test"] } }] }] }
     assert_equal expected, pipeline.to_h
@@ -505,7 +491,6 @@ class TestRakeCommand < TestCase
           { "docker-compose#v1.0" =>
             { "env" => ["PRE_STEPS", "RACK"],
             "run" => "default",
-            "pull" => "default",
             "config" => ".buildkite/docker-compose.yml",
             "shell" => ["runner", "activerecord"] } }] }] }
     assert_equal expected, pipeline.to_h
@@ -537,7 +522,6 @@ class TestRakeCommand < TestCase
           { "docker-compose#v1.0" =>
             { "env" => ["PRE_STEPS", "RACK"],
             "run" => "mysqldb",
-            "pull" => "mysqldb",
             "config" => ".buildkite/docker-compose.yml",
             "shell" => ["runner", "activerecord"] } }] }] }
     assert_equal expected, pipeline.to_h
@@ -569,7 +553,6 @@ class TestRakeCommand < TestCase
           { "docker-compose#v1.0" =>
             { "env" => ["PRE_STEPS", "RACK"],
             "run" => "mysqldb",
-            "pull" => "mysqldb",
             "config" => ".buildkite/docker-compose.yml",
             "shell" => ["runner", "activerecord"] } }] }] }
     assert_equal expected, pipeline.to_h
@@ -601,7 +584,6 @@ class TestRakeCommand < TestCase
           { "docker-compose#v1.0" =>
             { "env" => ["PRE_STEPS", "RACK"],
             "run" => "postgresdb",
-            "pull" => "postgresdb",
             "config" => ".buildkite/docker-compose.yml",
             "shell" => ["runner", "activerecord"] } }] }] }
     assert_equal expected, pipeline.to_h


### PR DESCRIPTION
That pull take 30-40s per job, which is quite insane when these image rarely if ever change.

Of course if they significantly change it would cause problem, but then we should probably find another way to deal with this like running a specific tag that is committed in this repo and that we manually update once in a while.

Ref: https://github.com/rails/buildkite-config/pull/73#discussion_r1484091872

cc @zzak 