### PR TITLE
Use a SELECT query for mysql healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,8 +137,8 @@ services:
     image: "${MYSQL_IMAGE-mysql:latest}"
     command: "--default-authentication-plugin=mysql_native_password"
     healthcheck:
-      test: mysqladmin -h localhost -P 3306 ping --silent
-      interval: 10s
+      test: mysql -h localhost -P 3306 -e "SELECT 1;"
+      interval: 1s
       retries: 60
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
@@ -149,7 +149,7 @@ services:
     <<: *mysql-defaults
     healthcheck:
       test: healthcheck.sh --su-mysql --connect --innodb_initialized
-      interval: 10s
+      interval: 1s
       retries: 60
 
   postgres:


### PR DESCRIPTION
Since updating the MySQL healthcheck to use mysqladmin, there has been an increase in failing buildkite jobs that report being unable to connect to MySQL. This behavior is consistent with reports on stackoverflow that the mysqladmin check is unfortunately not a reliable way to know whether the database is ready for connections.

This commit changes the MySQL healthcheck to be a `SELECT 1;` query. This should ensure that the MySQL is not only started but additionally ready for connections before reporting as healthy. Additionally, the interval for the healthcheck was reduced to 1s so that it has the potential to pass faster instead of only in 10s intervals.

stackoverflow: https://stackoverflow.com/questions/42567475/docker-compose-check-if-mysql-connection-is-ready/45058879