### PR TITLE
Hard fail ruby nigthly jobs

### DIFF
--- a/lib/buildkite/config/ruby_config.rb
+++ b/lib/buildkite/config/ruby_config.rb
@@ -7,17 +7,17 @@ module Buildkite::Config
 
     class << self
       def master_ruby
-        new(version: MASTER_RUBY_IMAGE, soft_fail: true)
+        new(version: MASTER_RUBY_IMAGE)
       end
 
       def master_debug_ruby
-        new(version: MASTER_DEBUG_RUBY_IMAGE, soft_fail: true)
+        new(version: MASTER_DEBUG_RUBY_IMAGE)
       end
 
       def yjit_ruby
         # Adds yjit: onto the master ruby image string so we
         # know when to turn on YJIT via the environment variable.
-        new(version: "yjit:#{MASTER_RUBY_IMAGE}", soft_fail: true, yjit: true)
+        new(version: "yjit:#{MASTER_RUBY_IMAGE}", yjit: true)
       end
     end
 

--- a/test/buildkite_config/test_rake_command.rb
+++ b/test/buildkite_config/test_rake_command.rb
@@ -292,8 +292,7 @@ class TestRakeCommand < TestCase
     assert_includes pipeline.to_h["steps"][0]["env"], "RUBY_YJIT_ENABLE"
     assert_equal "1", pipeline.to_h["steps"][0]["env"]["RUBY_YJIT_ENABLE"]
 
-    assert_includes pipeline.to_h["steps"][0], "soft_fail"
-    assert_equal true, pipeline.to_h["steps"][0]["soft_fail"]
+    assert_not_includes pipeline.to_h["steps"][0], "soft_fail"
   end
 
   def test_env_pre_steps


### PR DESCRIPTION
Now that it's in a separate pipeline, it doesn't make much sense to soft fail it, as it makes it harder to notice ruby-head has failures from the build list.