### PR TITLE
Fix docs-preview pipeline

### DIFF
--- a/pipelines/docs-preview/initial.yml
+++ b/pipelines/docs-preview/initial.yml
@@ -39,6 +39,7 @@ steps:
       - artifacts#v1.9.3:
           upload:
             - .buildkite/.empty
+            - .buildkite/bin/docs-preview-annotate
             - .buildkite/docker-compose.yml
             - .buildkite/Dockerfile
             - .buildkite/Dockerfile.beanstalkd


### PR DESCRIPTION
This PR makes sure the project can exists prior to deploying the pages. Since the Cloudflare Pages UI requires connecting to git, they assume you want to use their builders and create a project with the same name as the repository. However, for this project we want to specifically create a separate pipeline for previews.

Once this PR is merged, there are two remaining tasks:

* Get the `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` added to bk agents
* Turn on webhooks in the bk pipeline for github: https://buildkite.com/rails/docs-preview/settings/repository

After this is in place and the first pipeline is deployed, we should be able to remove the `wrangler pages project create` command.

Also, after #95 was merged, we had to update the annotate command given the new location for the script and selective artifacts tarball.