### PR TITLE
Move preview tarball outside workdir

### DIFF
--- a/pipelines/docs-preview/initial.yml
+++ b/pipelines/docs-preview/initial.yml
@@ -2,9 +2,6 @@
 # configuration in the Buildkite UI.
 
 steps:
-  - block: "Approve"
-    prompt: |
-      Only team members can approve this pipeline.
   - name: ":pipeline: docs-preview-initial-pipeline"
     command: |
       PATH=/bin:/usr/bin


### PR DESCRIPTION
Note: this is blocked by #99, and rails/rails#51650.

The idea is that we make sure any user-supplied tarball is handled outside of the working directory, in order to avoid any possible shenanigans with `npx`.

I've also removed the approval step so PRs are deployed automatically, since that extra bit of friction was only there to prevent any scenario where a bad actor can obtain the Cloudflare API key and publish malware on a (somewhat official Rails-looking domain) undetected.