### PR TITLE
Remove create project as initial build succeeded

### DIFF
--- a/pipelines/docs-preview/pipeline.rb
+++ b/pipelines/docs-preview/pipeline.rb
@@ -59,7 +59,6 @@ Buildkite::Builder.pipeline do
     command "tar -xzf preview.tar.gz -C /tmp/preview"
     command "rm preview.tar.gz"
     command "npm install wrangler@3"
-    command "npx wrangler@3 pages project create \"$$CLOUDFLARE_PAGES_PROJECT\" --production-branch=\"main\" || true"
     command "npx wrangler@3 pages deploy /tmp/preview --project-name=\"$$CLOUDFLARE_PAGES_PROJECT\" --branch=\"$BUILDKITE_BRANCH\""
   end
 


### PR DESCRIPTION
The project was created successfully, so we can remove this part now.

```
✘ [ERROR] A request to the Cloudflare API (/accounts/54aafc02b891b0d13e7e56083770f1af/pages/projects) failed.
  A project with this name already exists. Choose a different project name. [code: 8000002]
```

The step still passes (`|| true`), but we don't need this code anymore.