### PR TITLE
Avoid mounting checkout for docs-preview and docs-preview-annotate jobs

### DIFF
--- a/bin/docs-preview-annotate
+++ b/bin/docs-preview-annotate
@@ -29,7 +29,10 @@ json = JSON.parse(response.body)
 result = json["result"].first
 
 plan = <<~PLAN
-#### :writing_hand: rails/docs-preview: <a href="#{result["url"]}">:link: Preview URL</a>
+#### :writing_hand: rails/docs-preview:
+
+* <a href="#{result["url"]}/api">:link: API</a>
+* <a href="#{result["url"]}/guides">:link: Guides</a>
 PLAN
 
 puts plan

--- a/pipelines/docs-preview/pipeline.rb
+++ b/pipelines/docs-preview/pipeline.rb
@@ -50,14 +50,16 @@ Buildkite::Builder.pipeline do
         "WRANGLER_SEND_METRICS=false"
       ],
       image: "node:latest",
-      tty: false
+      mount_checkout: false,
+      tty: false,
+      volumes: ["./preview.tar.gz:/tmp/preview.tar.gz"],
+      workdir: "/workdir"
     }
     plugin :artifacts, {
       download: "preview.tar.gz"
     }
     command "mkdir /tmp/preview"
-    command "tar -xzf preview.tar.gz -C /tmp/preview"
-    command "rm preview.tar.gz"
+    command "tar -xzf /tmp/preview.tar.gz -C /tmp/preview"
     command "npm install wrangler@3"
     command "npx wrangler@3 pages project create \"$$CLOUDFLARE_PAGES_PROJECT\" --production-branch=\"main\" || true"
     command "npx wrangler@3 pages deploy /tmp/preview --project-name=\"$$CLOUDFLARE_PAGES_PROJECT\" --branch=\"$BUILDKITE_BRANCH\""
@@ -74,10 +76,11 @@ Buildkite::Builder.pipeline do
     # CLOUDFLARE_API_TOKEN is used to fetch preview URL from latest deployment
     env "ANNOTATE_COMMAND" => <<~ANNOTATE.gsub(/[[:space:]]+/, " ").strip
       docker run --rm
-      -v "$$PWD":/app:ro -w /app
       -e CLOUDFLARE_ACCOUNT_ID
       -e CLOUDFLARE_API_TOKEN
       -e CLOUDFLARE_PAGES_PROJECT
+      -v ./.buildkite:/workdir/.buildkite
+      -w /workdir
       ruby:latest
       ruby .buildkite/bin/docs-preview-annotate
     ANNOTATE


### PR DESCRIPTION
This is to avoid mounting the checkout (of head or branch/PR) when deploying the docs-preview or generating the annotation, as a safety mechanism.

Also added a minor UX improvement to link directly to the API and Guides in the annotation.