### PR TITLE
Remove usage of --default-authentication-plugin=mysql_native_password

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,7 +135,6 @@ services:
 
   mysql: &mysql-defaults
     image: "${MYSQL_IMAGE-mysql:latest}"
-    command: "--default-authentication-plugin=mysql_native_password"
     healthcheck:
       test: mysql -h localhost -P 3306 -e "SELECT 1;"
       interval: 1s


### PR DESCRIPTION
MySQL 8.4 has this plugin disabled by default, and trilogy already suppoots the new default authentication plugin, so we can now swap to the new default.