### PR TITLE
Skip the skip

### DIFF
--- a/lib/buildkite/config/rake_command.rb
+++ b/lib/buildkite/config/rake_command.rb
@@ -64,7 +64,7 @@ module Buildkite::Config
     end
 
     dsl do
-      def bundle(command, label:)
+      def bundle(command, label:, env: nil)
         build_context = context.extensions.find(BuildContext)
 
         command do
@@ -74,7 +74,7 @@ module Buildkite::Config
 
           install_plugins
 
-          env build_env(build_context, nil, nil)
+          env build_env(build_context, nil, env)
 
           agents queue: build_context.run_queue
 

--- a/lib/buildkite/config/ruby_group.rb
+++ b/lib/buildkite/config/ruby_group.rb
@@ -8,7 +8,6 @@ module Buildkite::Config
       def ruby_group(config, &block)
         build_context = context.extensions.find(BuildContext)
         build_context.ruby = config
-
         group do
           label build_context.ruby.version.to_s
           instance_eval(&block) if block_given?


### PR DESCRIPTION
Buildkite taught me about the `skip` attribute for command steps, so we can avoid allocating an agent just to print "skipping" message.

We also want to make sure linter is still run regardless of the skip attribute. Since it can detect documentation bugs in the guides, changelogs, etc.

This requires the image build always runs.