### PR TITLE
Remove bundle install from docs-preview pipeline

### DIFF
--- a/pipelines/docs-preview/pipeline.rb
+++ b/pipelines/docs-preview/pipeline.rb
@@ -15,7 +15,7 @@ Buildkite::Builder.pipeline do
   command do
     label "build", emoji: :rails
     key "build"
-    command "bundle install && bundle exec rake preview_docs"
+    command "bundle exec rake preview_docs"
     plugin :docker, {
       image: build_context.image_name_for("br-main", prefix: nil),
       environment: [
@@ -27,7 +27,6 @@ Buildkite::Builder.pipeline do
         "BUILDKITE_MESSAGE",
         "BUILDKITE_PULL_REQUEST",
         "BUILDKITE_REPO",
-        "BUNDLE_WITHOUT=db:job:cable:storage:ujs",
       ],
     }
     plugin :artifacts, {


### PR DESCRIPTION
The reason for `bundle install` was because the initial PR we used the `ruby:latest` docker image, which doesn't have any dependencies pre-installed.

As such, we needed `BUNDLE_WITHOUT` to prevent installing gems which depend on native extensions also missing from that image.

Since we switched to using a pre-built mainline image, all of the necessary dependencies should be there and we can remove this step to save time.

---

This is hard to test without access to the images on ECR, but I can imagine a possible race-condition where a dependency is changed in the gemfile and a docs-preview build is triggered before that image can reach the cache. It should be rare though, and a rebuild should fix it.