### PR TITLE
Remove `version` that is obsolete

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.6"
-
 services:
   base:
     build:


### PR DESCRIPTION
This commit removes the obsolete `version` from docker-compose.yml

- Steps to reproduce
```ruby
git clone https://github.com/rails/rails
cd rails
git clone https://github.com/rails/buildkite-config .buildkite/
RUBY_IMAGE=ruby:3.3 docker compose -f .buildkite/docker-compose.yml build base
```

- Without this commit, it shows this warning.
```ruby
WARN[0000] /home/yahonda/rails/.buildkite/docker-compose.yml: `version` is obsolete
```

Refer to https://github.com/compose-spec/compose-spec/pull/489