### PR TITLE
Add Rack 3.0 jobs, and only run Rack 3+ jobs on Rails 7.1+

### DIFF
--- a/lib/buildkite/config/build_context.rb
+++ b/lib/buildkite/config/build_context.rb
@@ -138,6 +138,10 @@ module Buildkite::Config
       rails_version >= Gem::Version.new("7.1.0.beta1")
     end
 
+    def test_with_multiple_versions_of_rack?(ruby)
+      ruby == default_ruby && rails_version >= Gem::Version.new("7.1.x")
+    end
+
     def build_queue
       ENV["BUILD_QUEUE"] || queue || "builder"
     end

--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -62,11 +62,12 @@ Buildkite::Builder.pipeline do
       rake "actionmailer"
       rake "actionpack"
 
-      if ruby == build_context.default_ruby
+      if ruby == build_context.default_ruby && build_context.rails_version >= Gem::Version.new("7.1.x")
         rake "actionpack",
           pre_steps: ["bundle install"],
           label: "[rack-2]",
           env: { RACK: "~> 2.0" }
+
         rake "actionpack",
           pre_steps: ["bundle install"],
           label: "[rack-3-0]",
@@ -133,7 +134,7 @@ Buildkite::Builder.pipeline do
 
       rake "railties", service: "railties", parallelism: 12
 
-      if ruby == build_context.default_ruby
+      if ruby == build_context.default_ruby && build_context.rails_version >= Gem::Version.new("7.1.x")
         rake "railties",
           service: "railties",
           pre_steps: ["bundle install"],

--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -68,6 +68,10 @@ Buildkite::Builder.pipeline do
           label: "[rack-2]",
           env: { RACK: "~> 2.0" }
         rake "actionpack",
+          pre_steps: ["bundle install"],
+          label: "[rack-3-0]",
+          env: { RACK: "~> 3.0.0" }
+        rake "actionpack",
           pre_steps: ["rm Gemfile.lock", "bundle install"],
           label: "[rack-head]",
           env: { RACK: "head" },
@@ -136,6 +140,13 @@ Buildkite::Builder.pipeline do
           parallelism: 12,
           label: "[rack-2]",
           env: { RACK: "~> 2.0" }
+
+        rake "railties",
+          service: "railties",
+          pre_steps: ["bundle install"],
+          parallelism: 12,
+          label: "[rack-3-0]",
+          env: { RACK: "~> 3.0.0" }
 
         rake "railties",
           service: "railties",

--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -62,7 +62,7 @@ Buildkite::Builder.pipeline do
       rake "actionmailer"
       rake "actionpack"
 
-      if ruby == build_context.default_ruby && build_context.rails_version >= Gem::Version.new("7.1.x")
+      if build_context.test_with_multiple_versions_of_rack?(ruby)
         rake "actionpack",
           pre_steps: ["bundle install"],
           label: "[rack-2]",
@@ -72,6 +72,7 @@ Buildkite::Builder.pipeline do
           pre_steps: ["bundle install"],
           label: "[rack-3-0]",
           env: { RACK: "~> 3.0.0" }
+
         rake "actionpack",
           pre_steps: ["rm Gemfile.lock", "bundle install"],
           label: "[rack-head]",
@@ -134,7 +135,7 @@ Buildkite::Builder.pipeline do
 
       rake "railties", service: "railties", parallelism: 12
 
-      if ruby == build_context.default_ruby && build_context.rails_version >= Gem::Version.new("7.1.x")
+      if build_context.test_with_multiple_versions_of_rack?(ruby)
         rake "railties",
           service: "railties",
           pre_steps: ["bundle install"],

--- a/test/buildkite_config/test_build_context.rb
+++ b/test/buildkite_config/test_build_context.rb
@@ -571,4 +571,24 @@ class TestBuildContext < TestCase
       assert_predicate sub, :support_guides_lint?
     end
   end
+
+  def test_test_with_multiple_versions_of_rack
+    sub = create_build_context
+
+    sub.default_ruby = Buildkite::Config::RubyConfig.master_ruby
+
+    sub.stub(:rails_version, Gem::Version.new("7.0.0")) do
+      assert_equal false, sub.test_with_multiple_versions_of_rack?(Buildkite::Config::RubyConfig.master_ruby)
+    end
+
+    sub.stub(:rails_version, Gem::Version.new("7.2.0")) do
+      assert_equal false, sub.test_with_multiple_versions_of_rack?(Buildkite::Config::RubyConfig.new(version: Gem::Version.new("3.2")))
+    end
+
+    sub.stub(:rails_version, Gem::Version.new("7.2.0")) do
+      assert_equal true, sub.test_with_multiple_versions_of_rack?(Buildkite::Config::RubyConfig.master_ruby)
+    end
+
+    Buildkite::Config::RubyConfig.new(version: Gem::Version.new("3.2"))
+  end
 end

--- a/test/buildkite_config/test_rake_command.rb
+++ b/test/buildkite_config/test_rake_command.rb
@@ -42,7 +42,7 @@ class TestRakeCommand < TestCase
       end
     end
 
-    expected = { "steps" => [{ "depends_on" => ["rubylang/ruby:master-nightly-jammy"] }] }
+    expected = { "steps" => [{ "depends_on" => ["rubylang/ruby:master"] }] }
     assert_equal expected, pipeline.to_h
   end
 


### PR DESCRIPTION
[Add Rack 3.0 jobs](https://github.com/rails/buildkite-config/commit/6b7fa4414431b49a0edd07ca62ece49abc2be912)

Since the release of Rack 3.1, we are now only testing against Rack 2
and Rack 3.1. This is a problem because their are behavioral changes
made between 3.0 and 3.1 (such as `rack.input` now being optional).

To ensure that we stay compatible with all of the versions we claim to
be compatible with, this commit adds actionpack and railties jobs for
Rack 3.0.

---

[Only run extra Rack jobs on Rails 7.1+](https://github.com/rails/buildkite-config/pull/110/commits/0c33b70475010b757fa2830ccd0ecd88365e6d0c)

Rails <= 7.0 does not support Rack 3, so any `rack-3-0` and `rack-head`
jobs will necessarily fail. Additionally, `rack-2` is not needed because
the default jobs are already testing Rack 2.