### PR TITLE
Skip old branches and add timeout

### DIFF
--- a/pipelines/docs-preview/pipeline.rb
+++ b/pipelines/docs-preview/pipeline.rb
@@ -12,6 +12,16 @@ Buildkite::Builder.pipeline do
 
   env CLOUDFLARE_PAGES_PROJECT: "rails-docs-preview"
 
+  if build_context.rails_version < Gem::Version.new("7.2.x")
+    command do
+      label ":bk-status-passed: Build skipped"
+      skip true
+      command "true"
+    end
+
+    next
+  end
+
   command do
     label "build", emoji: :rails
     key "build"

--- a/pipelines/docs-preview/pipeline.rb
+++ b/pipelines/docs-preview/pipeline.rb
@@ -26,6 +26,7 @@ Buildkite::Builder.pipeline do
     label "build", emoji: :rails
     key "build"
     command "bundle exec rake preview_docs"
+    timeout_in_minutes 15
     plugin :docker, {
       image: build_context.image_name_for("br-main", prefix: nil),
       environment: [
@@ -48,6 +49,7 @@ Buildkite::Builder.pipeline do
     label "deploy", emoji: :rocket
     key "deploy"
     depends_on "build"
+    timeout_in_minutes 15
     plugin :docker, {
       environment: [
         "BUILDKITE_BRANCH",
@@ -76,6 +78,7 @@ Buildkite::Builder.pipeline do
   command do
     label "annotate", emoji: :writing_hand
     depends_on "deploy"
+    timeout_in_minutes 15
     plugin :artifacts, {
       download: ".buildkite/bin/docs-preview-annotate",
       compressed: ".buildkite.tgz"


### PR DESCRIPTION
This PR changes the `docs-preview` pipeline to skip when building older stable branches, since the rake task only exists since the 7-2-stable branch.

This job would fail for backport PRs which may be confusing to contributors, and I don't think it's necessary to backport the rake task to show doc previews for bug fixes to <= 7.1. Let's focus on making 7.2+ docs better.

I've also added a timeout of 15 minutes on all steps in this pipeline, since there was none and I found a job which ran over 4 hours: https://buildkite.com/rails/docs-preview/builds/1836#01904172-0201-497e-97e8-e211e2db9561

Whoops!