### PR TITLE
Use `rubylang/ruby:master` and `rubylang/ruby:master-debug` image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,11 @@ RUN echo "--- :ruby: Updating RubyGems and Bundler" \
                 echo 'libmysqlclient-dev'; \
             fi \
         ) \
+        $( \
+            if apt-cache show 'tzdata-legacy' 2>/dev/null | grep -q '^Version:'; then \
+                echo 'tzdata-legacy'; \
+            fi \
+        ) \
     #  specific dependencies for the rails build
     && apt-get install -y --no-install-recommends \
         postgresql-client default-mysql-client sqlite3 \

--- a/lib/buildkite/config/ruby_config.rb
+++ b/lib/buildkite/config/ruby_config.rb
@@ -2,8 +2,8 @@
 
 module Buildkite::Config
   class RubyConfig
-    MASTER_RUBY_IMAGE = "rubylang/ruby:master-nightly-jammy"
-    MASTER_DEBUG_RUBY_IMAGE = "rubylang/ruby:master-debug-nightly-jammy"
+    MASTER_RUBY_IMAGE = "rubylang/ruby:master"
+    MASTER_DEBUG_RUBY_IMAGE = "rubylang/ruby:master-debug"
 
     class << self
       def master_ruby


### PR DESCRIPTION
This pull request updates Ruby docker images used at Rails Nightly https://buildkite.com/rails/rails-nightly It has two changes:

#### Use `rubylang/ruby:master` and `rubylang/ruby:master-debug` image without Ubuntu codename suffix

`rubylang/ruby:master` and `rubylang/ruby:master-debug` images without Ubuntu codename suffix are available since https://github.com/ruby/docker-images/pull/102/files We will not have to update these lines every two years.

#### nstall `tzdata-legacy` package if available

Starting from Ubuntu 23.10 some of tzdata package contents moved into `tzdata-legacy` that affects Active Support code as per reported https://github.com/rails/rails/issues/49648 . Ubuntu 24.04 requires the `tzdata-legacy` package while Debian “bookworm” based docker image like `ruby:3.3` does not have `tzdata-legacy` so it installs `tzdata-legacy` package only if available.

### Additional information
This commit have been verified locally:

- rubylang/ruby:master image based on Ubuntu 24.04
```
RUBY_IMAGE=rubylang/ruby:master docker compose -f .buildkite/docker-compose.yml build base && IMAGE_NAME=buildkite-base docker compose -f .buildkite/docker-compose.yml run -e RAILS_STRICT_WARNINGS=1 default runner activesupport 'rake test'
```

- rubylang/ruby:master image based on Ubuntu 24.04
```
RUBY_IMAGE=rubylang/ruby:master-debug docker compose -f .buildkite/docker-compose.yml build base && IMAGE_NAME=buildkite-base docker compose -f .buildkite/docker-compose.yml run -e RAILS_STRICT_WARNINGS=1 default runner activesupport 'rake test'
```

- ruby:3.3 image based on Debian "bookworm"
```
RUBY_IMAGE=ruby:3.3 docker compose -f .buildkite/docker-compose.yml build base && IMAGE_NAME=buildkite-base docker compose -f .buildkite/docker-compose.yml run -e RAILS_STRICT_WARNINGS=1 default runner activesupport 'rake test'
```