### PR TITLE
Fix docs-preview pipeline

### DIFF
--- a/pipelines/docs-preview/pipeline.rb
+++ b/pipelines/docs-preview/pipeline.rb
@@ -25,7 +25,7 @@ Buildkite::Builder.pipeline do
   command do
     label "build", emoji: :rails
     key "build"
-    command "bundle exec rake preview_docs"
+    command "bundle install && bundle exec rake preview_docs"
     timeout_in_minutes 15
     plugin :docker, {
       image: build_context.image_name_for("br-main", prefix: nil),


### PR DESCRIPTION
The `bundle install` was removed in 5dbaed174ffb21371f415c6bc611f065b981171e because I had assumed that using the pre-built image would be enough.

However, the builds started failing due to this change: https://buildkite.com/rails/docs-preview/builds/1940