### PR TITLE
Enable YJIT to build docs-preview

### DIFF
--- a/pipelines/docs-preview/pipeline.rb
+++ b/pipelines/docs-preview/pipeline.rb
@@ -38,6 +38,7 @@ Buildkite::Builder.pipeline do
         "BUILDKITE_MESSAGE",
         "BUILDKITE_PULL_REQUEST",
         "BUILDKITE_REPO",
+        "RUBY_YJIT_ENABLE",
       ],
     }
     plugin :artifacts, {


### PR DESCRIPTION
I've found that it speeds up doc building for me locally, so it seems like a good idea to try in CI as well