### PR TITLE
Fix another issue with mysql healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,7 +134,7 @@ services:
   mysql: &mysql-defaults
     image: "${MYSQL_IMAGE-mysql:latest}"
     healthcheck:
-      test: mysql -h localhost -P 3306 -e "SELECT 1;"
+      test: mysql -h 127.0.0.1 -P 3306 -e "SELECT 1;"
       interval: 1s
       retries: 60
     environment:


### PR DESCRIPTION
Ref https://github.com/docker-library/mysql/issues/930

There have many many flaky CI runs since the await script was replaced with docker healthchecks. The MySQL service will report a healthy status, but then the test container is unable to connect to it.

There was an attempt [previously][1] to fix this, but that change does not seem to have fixed the issue.

Looking into this issue further has pointed me to a potential cause: the default mysql docker images will boot up mysql twice. The first time it starts up a temporary server for init purposes, and the second time is the "real" mysqld. The current healthcheck doesn't differentiate between the two servers, so it passes even when the "real" server isn't running.

However, we should be able to differentiate the two servers because the init server is started with `--skip-networking=ON`. As long as the healthcheck uses TCP to try to connect, it should not succeed on the init server. The problem with the current healthcheck is that it uses `localhost`, which is treated specially by MySQL:

> On Unix, MySQL programs treat the host name localhost specially, in a
> way that is likely different from what you expect compared to other
> network-based programs: the client connects using a Unix socket file.

So by changing the `host` param in the healthcheck from `localhost` to `127.0.0.1`, we can ensure that the connection is made using TCP and we should no longer see flaky mysql CI jobs.

[1]: https://github.com/rails/buildkite-config/commit/e9d3dc4779ed5fa4e282c45ac2b1e34f563c14d6