### PR TITLE
Allow overriding compose env for local builds

### DIFF
--- a/lib/buildkite/config/rake_command.rb
+++ b/lib/buildkite/config/rake_command.rb
@@ -101,7 +101,7 @@ module Buildkite::Config
           depends_on "docker-image-#{build_context.ruby.image_key}"
           command "rake #{task}"
 
-          install_plugins(service,  %w[PRE_STEPS RACK], dir, compose: compose)
+          install_plugins(service, %w[PRE_STEPS RACK], dir, compose: compose)
 
           env build_env(build_context, pre_steps, env)
 


### PR DESCRIPTION
Now we can write this very simple pipeline for debugging builds locally.

```ruby
Buildkite::Builder.pipeline do
  require "buildkite_config"
  use Buildkite::Config::BuildContext
  use Buildkite::Config::DockerBuild
  use Buildkite::Config::RakeCommand
  use Buildkite::Config::RubyGroup

  plugin :docker_compose, "docker-compose#v4.16.0"
  plugin :artifacts, "artifacts#v1.9.3"

  build_context.setup_rubies %w(3.3)

  group do
    label "build"
    build_context.rubies.each do |ruby|
      builder ruby, compose: {
        "cli_version": "2",
        "image-name": "buildkite_base",
        "cache-from": ["buildkite_base"],
        "push": "",
        "image-repository": "",
      }
    end
  end

  build_context.rubies.each do |ruby|
    ruby_group ruby do
      rake "actioncable", task: "test:integration", retry_on: { exit_status: -1, limit: 3 }, compose: {
        "cli_version": "2",
        "pull": "",
      }, env: {
        "IMAGE_NAME": "buildkite_base",
      }
    end
  end
end
```

I needed this to run builds on a local VM, where I don't have access to a docker image host and a newer version of docker/compose.