### PR TITLE
Action Cable integration test should soft fail on exit 3

### DIFF
--- a/lib/buildkite/config/rake_command.rb
+++ b/lib/buildkite/config/rake_command.rb
@@ -106,16 +106,17 @@ module Buildkite::Config
 
           artifact_paths build_context.artifact_paths
 
-          if retry_on
-            automatic_retry_on(**retry_on)
-          else
-            automatic_retry_on(**build_context.automatic_retry_on)
+          [retry_on].flatten.compact.each do |retry_args|
+            automatic_retry_on(**retry_args)
           end
+          automatic_retry_on(**build_context.automatic_retry_on)
 
           timeout_in_minutes build_context.timeout_in_minutes
 
-          if soft_fail || build_context.ruby.soft_fail?
+          if soft_fail.is_a?(TrueClass) || build_context.ruby.soft_fail?
             soft_fail true
+          else
+            soft_fail([soft_fail].flatten.compact) if soft_fail
           end
 
           if parallelism

--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -160,7 +160,7 @@ Buildkite::Builder.pipeline do
       end
 
       # ActionCable and ActiveJob integration tests
-      rake "actioncable", task: "test:integration", retry_on: { exit_status: -1, limit: 3 }
+      rake "actioncable", task: "test:integration", retry_on: { exit_status: 3, limit: 1 }, soft_fail: { exit_status: 3 }
 
       if ruby == build_context.default_ruby
         if build_context.rails_root.join("actionview/Rakefile").read.include?("task :ujs")


### PR DESCRIPTION
This is to support rails/rails#51990.

Inside the `actioncable test:integration` job, we capture the output and look for `The environment you requested was unavailable` which happens far too often: https://buildkite.com/rails/rails/builds/111313#0191e945-faef-4d92-8f8a-74dbd1d397db

If we capture that output, the job will `exit 3`.

In this PR, we've added a retry policy for 1 extra retry (2 total attempts) and to mark the job as soft_fail if the exit status 3 persists.

This should cut down on flaky builds due to `actioncable:integration` step failing.

I've tested the behavior locally in various scenarios.