### PR TITLE
Add Ruby 3.4.0-preview2 to CI

### DIFF
--- a/lib/buildkite/config/build_context.rb
+++ b/lib/buildkite/config/build_context.rb
@@ -41,8 +41,9 @@ module Buildkite::Config
     end
 
     def setup_rubies(ruby_minors)
-      @rubies = ruby_minors.sort.map { |m| Gem::Version.new(m) }.select { |v| v >= min_ruby }.map do |v|
-        rc = RubyConfig.new(version: v, prefix: "ruby:")
+      @rubies = ruby_minors.sort.select { |v| Gem::Version.new(v) >= min_ruby }.map do |m|
+        v = Gem::Version.new(m)
+        rc = RubyConfig.new(version: m, prefix: "ruby:")
 
         if max_ruby && v > max_ruby && !(max_ruby.approximate_recommendation === v)
           rc.soft_fail = true

--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -16,7 +16,7 @@ Buildkite::Builder.pipeline do
     build_context.rubies << Buildkite::Config::RubyConfig.master_debug_ruby
     build_context.default_ruby = Buildkite::Config::RubyConfig.master_ruby
   else
-    build_context.setup_rubies %w(2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3)
+    build_context.setup_rubies %w(2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3 3.4.0-preview2)
   end
 
   group do

--- a/test/buildkite_config/test_build_context.rb
+++ b/test/buildkite_config/test_build_context.rb
@@ -157,11 +157,23 @@ class TestBuildContext < TestCase
       end
     end
 
-    expected = Buildkite::Config::RubyConfig.new(prefix: "ruby:", version: Gem::Version.new("3.3"))
+    expected = Buildkite::Config::RubyConfig.new(prefix: "ruby:", version: "3.3")
 
-    assert_equal sub.rubies.first.version, expected.version
-    assert_equal sub.rubies.first.prefix, expected.prefix
-    assert_equal sub.default_ruby.version, Gem::Version.new("3.2")
+    assert_equal expected.version, sub.rubies.first.version
+    assert_equal expected.prefix, sub.rubies.first.prefix
+    assert_equal "3.2", sub.default_ruby.version
+  end
+
+  def test_setup_preview_rubies
+    sub = create_build_context
+
+    sub.stub(:min_ruby, Gem::Version.new("2.7")) do
+      sub.stub(:max_ruby, Gem::Version.new("3.5")) do
+        sub.setup_rubies %w(3.4.0-preview2 3.3 3.2 3.1 3.0)
+      end
+    end
+
+    assert_equal "3.4.0-preview2", sub.default_ruby.version.to_s
   end
 
   def test_setup_rubies_default_ruby
@@ -173,11 +185,11 @@ class TestBuildContext < TestCase
       end
     end
 
-    expected = Buildkite::Config::RubyConfig.new(prefix: "ruby:", version: Gem::Version.new("3.3"))
+    expected = Buildkite::Config::RubyConfig.new(prefix: "ruby:", version: "3.3")
 
-    assert_equal sub.rubies.first.version, expected.version
-    assert_equal sub.rubies.first.prefix, expected.prefix
-    assert_equal Gem::Version.new("3.2"), sub.default_ruby.version
+    assert_equal expected.version, sub.rubies.first.version
+    assert_equal expected.prefix, sub.rubies.first.prefix
+    assert_equal "3.2", sub.default_ruby.version
   end
 
   def test_bundler_2_2


### PR DESCRIPTION
Rails 8.0 is currently in beta, likely will be released not long before Ruby 3.4 is, so we want to flush out any compatibility issues so that users can upgrade to Ruby 2.4 in January.