### PR TITLE
Automatically retry on exit code 255

### DIFF
--- a/lib/buildkite/config/build_context.rb
+++ b/lib/buildkite/config/build_context.rb
@@ -159,7 +159,10 @@ module Buildkite::Config
     end
 
     def automatic_retry_on
-      { exit_status: -1, limit: 2 }
+      [
+        { exit_status: -1, limit: 2 },
+        { exit_status: 255, limit: 2 },
+      ]
     end
 
     def timeout_in_minutes

--- a/lib/buildkite/config/rake_command.rb
+++ b/lib/buildkite/config/rake_command.rb
@@ -106,10 +106,12 @@ module Buildkite::Config
 
           artifact_paths build_context.artifact_paths
 
-          if retry_on
-            automatic_retry_on(**retry_on)
-          else
-            automatic_retry_on(**build_context.automatic_retry_on)
+          if retry_on ||= build_context.automatic_retry_on
+            retry_on = [retry_on] unless retry_on.is_a?(Array)
+
+            retry_on.each do |retry_rule|
+              automatic_retry_on(**retry_rule)
+            end
           end
 
           timeout_in_minutes build_context.timeout_in_minutes

--- a/test/buildkite_config/test_build_context.rb
+++ b/test/buildkite_config/test_build_context.rb
@@ -551,7 +551,7 @@ class TestBuildContext < TestCase
 
   def test_automatic_retry_on
     sub = create_build_context
-    assert_equal({ exit_status: -1, limit: 2 }, sub.automatic_retry_on)
+    assert_equal([{ exit_status: -1, limit: 2 }, { exit_status: 255, limit: 2 }], sub.automatic_retry_on)
   end
 
   def test_timeout_in_minutes

--- a/test/buildkite_config/test_rake_command.rb
+++ b/test/buildkite_config/test_rake_command.rb
@@ -129,7 +129,7 @@ class TestRakeCommand < TestCase
     end
 
     assert_includes pipeline.to_h["steps"][0], "retry"
-    assert_equal({ "automatic" => [{ "limit" => 2, "exit_status" => -1 }] }, pipeline.to_h["steps"][0]["retry"])
+    assert_equal({ "automatic" => [{ "limit" => 2, "exit_status" => -1 }, { "limit" => 2, "exit_status" => 255 }] }, pipeline.to_h["steps"][0]["retry"])
   end
 
   def test_env


### PR DESCRIPTION
I've seen quite a bit of

> Exited with status 255 (after intercepting the agent’s termination signal, sent because the agent was stopped)

On my PRs.