### PR TITLE
Tell the docker-compose plugin to retry pulls a few times

### DIFF
--- a/lib/buildkite/config/rake_command.rb
+++ b/lib/buildkite/config/rake_command.rb
@@ -53,6 +53,7 @@ module Buildkite::Config
           "env" => env,
           "run" => service,
           "pull" => service,
+          "pull-retries" => 3,
           "config" => ".buildkite/docker-compose.yml",
           "shell" => ["runner", *dir],
         }.compact

--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -30,15 +30,15 @@ Buildkite::Builder.pipeline do
   ruby_group build_context.default_ruby do
     label "lint"
 
-    bundle "exec rubocop --parallel", label: "rubocop"
+    bundle "rubocop --parallel", label: "rubocop"
 
     if build_context.support_guides_lint?
       rake "guides", task: "guides:lint"
     end
 
     if build_context.has_railspect?
-      bundle "exec tools/railspect changelogs .", label: "changelogs"
-      bundle "exec tools/railspect configuration .", label: "configuration"
+      bundle "tools/railspect changelogs .", label: "changelogs"
+      bundle "tools/railspect configuration .", label: "configuration"
     end
   end
 


### PR DESCRIPTION
We see a surprising number of these:

`Error response from daemon: Get "https://973266071021.dkr.ecr.us-east-1.amazonaws.com/v2/": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)`

We could also consider retrying the whole job on exit code 18, instead of or in addition to this change. For now let's start with the tighter, inline, retry here -- then we can consider checking the exit code if it seems that we sometimes end up with a truly un-network-able agent, rather than a transient blip.