### PR TITLE
Make sure to pass MYSQL_PREPARED_STATEMENTS to container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       BEANSTALK_URL: "beanstalk://beanstalkd"
       MEMCACHE_SERVERS: "memcached:11211"
       MYSQL_HOST: mysql
+      MYSQL_PREPARED_STATEMENTS:
       PGHOST: postgres
       PGUSER: postgres
       QC_DATABASE_URL: "postgres://postgres@postgres/active_jobs_qc_int_test"


### PR DESCRIPTION
We have to explicitly allow any environment variables we want to pass through to the container.

## How to test

```
cd ~/code/rails
gh pr checkout 53697
rsync -av --progress /home/zzak/code/buildkite-config/ .buildkite
RUBY_IMAGE="ruby:3.3" docker compose -f .buildkite/docker-compose.yml build base

MYSQL_PREPARED_STATEMENTS=true IMAGE_NAME="buildkite-base" RUBY_IMAGE="ruby:3.3" docker compose -f .buildkite/docker-compose.yml run mysqldb runner activerecord 'rake mysql2:test'
```

Also tested without the env var.