### PR TITLE
Run the guides only for Rails 7.2.x and higher

### DIFF
--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -130,7 +130,7 @@ Buildkite::Builder.pipeline do
 
       rake "activestorage"
       rake "activesupport"
-      rake "guides"
+      rake "guides" if build_context.rails_version >= Gem::Version.new("7.2.x")
 
       rake "railties", service: "railties", parallelism: 12
 


### PR DESCRIPTION
This pull request aims to run the guides only for Rails 7.2.x and higher.

Instead of make this CI green by specifying Rails version and sqlite3 version, https://buildkite.com/rails/rails/builds/113977#019351d1-4ecd-4552-b403-92317184d9bf

This commit skips guides for Rails 7.1.x and lower because Rails 7.1.x just accepts security fixes because these templates are for bug fixes.

This version specified in this pull request "7.2.x" needs bumped in future.