### PR TITLE
Use "mariadb:lts" to workaround CI failure

### DIFF
--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -90,7 +90,7 @@ Buildkite::Builder.pipeline do
         rake "activerecord", task: "mysql2:test",
           service: "mariadb",
           label: "[mariadb]",
-          env: { MYSQL_IMAGE: "mariadb:latest" }
+          env: { MYSQL_IMAGE: "mariadb:lts" }
 
         rake "activerecord", task: "mysql2:test",
           service: "mysqldb",
@@ -119,7 +119,7 @@ Buildkite::Builder.pipeline do
           rake "activerecord", task: "trilogy:test",
             service: "mariadb",
             label: "[mariadb]",
-            env: { MYSQL_IMAGE: "mariadb:latest" }
+            env: { MYSQL_IMAGE: "mariadb:lts" }
 
           rake "activerecord", task: "trilogy:test",
             service: "mysqldb",


### PR DESCRIPTION
This commit uses "mariadb:lts" that is MariaDB Server 11.4 until https://github.com/rails/rails/issues/53727 is resolved.

Refer to
* MariaDB Server 11.4 will be LTS https://mariadb.org/11-4-lts/