### PR TITLE
Use default pg user for healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,7 +153,7 @@ services:
   postgres:
     image: "${POSTGRES_IMAGE-postgres:alpine}"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
This silences the following errors in my docker logs:

```
postgres-1         | 2024-12-02 02:13:29.359 UTC [85235] FATAL:  role "root" does not exist
postgres-1         | 2024-12-02 02:13:39.415 UTC [85244] FATAL:  role "root" does not exist
postgres-1         | 2024-12-02 02:13:49.475 UTC [85253] FATAL:  role "root" does not exist
postgres-1         | 2024-12-02 02:13:59.519 UTC [85262] FATAL:  role "root" does not exist
```

The default user for this image is `postgres', which we don't change:
https://hub.docker.com/_/postgres

https://github.com/rails/buildkite-config/blob/13b395cd1a6ea11d9505a739826f4ba304562835/docker-compose.yml#L32