### PR TITLE
Disable `innodb_snapshot_isolation` for MariaDB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,6 +149,9 @@ services:
       test: healthcheck.sh --su-mysql --connect --innodb_initialized
       interval: 1s
       retries: 60
+    volumes:
+      - "./mysql-initdb.d:/docker-entrypoint-initdb.d"
+      - "./mariadb-conf.d/mariadb.cnf:/etc/mysql/conf.d/mariadb.cnf"
 
   postgres:
     image: "${POSTGRES_IMAGE-postgres:alpine}"

--- a/mariadb-conf.d/mariadb.cnf
+++ b/mariadb-conf.d/mariadb.cnf
@@ -1,0 +1,2 @@
+[mariadb]
+loose_innodb_snapshot_isolation = off

--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -90,7 +90,7 @@ Buildkite::Builder.pipeline do
         rake "activerecord", task: "mysql2:test",
           service: "mariadb",
           label: "[mariadb]",
-          env: { MYSQL_IMAGE: "mariadb:lts" }
+          env: { MYSQL_IMAGE: "mariadb:latest" }
 
         rake "activerecord", task: "mysql2:test",
           service: "mysqldb",
@@ -119,7 +119,7 @@ Buildkite::Builder.pipeline do
           rake "activerecord", task: "trilogy:test",
             service: "mariadb",
             label: "[mariadb]",
-            env: { MYSQL_IMAGE: "mariadb:lts" }
+            env: { MYSQL_IMAGE: "mariadb:latest" }
 
           rake "activerecord", task: "trilogy:test",
             service: "mysqldb",


### PR DESCRIPTION
This commit restores to use the `mariadb:latest` image and disables innodb_snapshot_isolation that is enabled by default since MariaDB 11.6.2 and 11.7.1 because it causes Rails CI failures as per reported https://github.com/rails/rails/issues/53727 .

- MariaDB 11.6.2 Release Notes https://mariadb.com/kb/en/mariadb-11-6-2-release-notes/
- MariaDB 11.7.1 Release Notes https://mariadb.com/kb/en/mariadb-11-7-1-release-notes/

> Defaults change - the innodb_snapshot_isolation system variable now defaults to ON, previously was OFF (MDEV-35124)

https://jira.mariadb.org/browse/MDEV-35124

The `loose` prefix is added to support MariaDB versions that does not have `innodb_snapshot_isolation`. It only exists at MariaDB Server 10.6.18, 10.11.8, 11.4.2 and later versions of MariaDB via https://github.com/MariaDB/server/commit/b8a671988954870b7db22e20d1a1409fd40f8e3d

- `--loose` prefix https://dev.mysql.com/doc/refman/8.4/en/option-modifiers.html

> The --loose prefix can be useful when you run programs from multiple installations of MySQL on the same machine and list options in an option file.
> An option that may not be recognized by all versions of a program can be given using the --loose prefix (or loose in an option file).
>  Versions of the program that recognize the option process it normally, and versions that do not recognize it issue a warning and ignore it.

- Custom configuration file for MariaDB can be used as explained below https://hub.docker.com/_/mariadb
> Custom configuration files should end in .cnf and be mounted read only at the directory /etc/mysql/conf.d.
> These files should contain the minimal changes from the MariaDB workload required for your application/environment.
> A MariaDB configuration file will have a [mariadb] group followed by variable = value settings