### PR TITLE
Revert "Disable `innodb_snapshot_isolation` for MariaDB"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,9 +149,6 @@ services:
       test: healthcheck.sh --su-mysql --connect --innodb_initialized
       interval: 1s
       retries: 60
-    volumes:
-      - "./mysql-initdb.d:/docker-entrypoint-initdb.d"
-      - "./mariadb-conf.d/mariadb.cnf:/etc/mysql/conf.d/mariadb.cnf"
 
   postgres:
     image: "${POSTGRES_IMAGE-postgres:alpine}"

--- a/mariadb-conf.d/mariadb.cnf
+++ b/mariadb-conf.d/mariadb.cnf
@@ -1,2 +1,0 @@
-[mariadb]
-loose_innodb_snapshot_isolation = off

--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -90,7 +90,7 @@ Buildkite::Builder.pipeline do
         rake "activerecord", task: "mysql2:test",
           service: "mariadb",
           label: "[mariadb]",
-          env: { MYSQL_IMAGE: "mariadb:latest" }
+          env: { MYSQL_IMAGE: "mariadb:lts" }
 
         rake "activerecord", task: "mysql2:test",
           service: "mysqldb",
@@ -119,7 +119,7 @@ Buildkite::Builder.pipeline do
           rake "activerecord", task: "trilogy:test",
             service: "mariadb",
             label: "[mariadb]",
-            env: { MYSQL_IMAGE: "mariadb:latest" }
+            env: { MYSQL_IMAGE: "mariadb:lts" }
 
           rake "activerecord", task: "trilogy:test",
             service: "mysqldb",


### PR DESCRIPTION
Reverts rails/buildkite-config#134

Looks like it doesn't work well.

https://buildkite.com/rails/rails/builds/114641#0193b412-58ee-47e5-94fc-5ef5c614abee/1260-1268