### PR TITLE
Add Ruby `3.4.0-rc1` image to Rails CI

### DIFF
--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -16,7 +16,7 @@ Buildkite::Builder.pipeline do
     build_context.rubies << Buildkite::Config::RubyConfig.master_debug_ruby
     build_context.default_ruby = Buildkite::Config::RubyConfig.master_ruby
   else
-    build_context.setup_rubies %w(2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3 3.4.0-preview2)
+    build_context.setup_rubies %w(2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3 3.4.0-rc1)
   end
 
   group do


### PR DESCRIPTION
This pull request adds Ruby `3.4.0-rc1` image to Rails CI.

* Ruby 3.4.0 rc1 Released https://www.ruby-lang.org/en/news/2024/12/12/ruby-3-4-0-rc1-released/

* `ruby:3.4.0-rc1` tag is available https://hub.docker.com/_/ruby

https://hub.docker.com/layers/library/ruby/3.4.0-rc1/images/sha256-eb37f58646a901dc7727cf448cae36daaefaba79de33b5058dab79aa4c04aefb?context=explore