### PR TITLE
Change the rabbitmq image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,7 +161,7 @@ services:
       POSTGRES_HOST_AUTH_METHOD: "trust"
 
   rabbitmq:
-    image: rabbitmq:alpine
+    image: rabbitmq-4:alpine
     healthcheck:
       test: rabbitmq-diagnostics -q ping
       interval: 30s


### PR DESCRIPTION
CI started failing with:

```
manifest for rabbitmq:alpine not found
```

It's unclear what's going on given this label is still displayed on https://hub.docker.com/_/rabbitmq.

But trying a sligthly more specific label might fix it.