### PR TITLE
Revert "Change the rabbitmq image"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,7 +161,7 @@ services:
       POSTGRES_HOST_AUTH_METHOD: "trust"
 
   rabbitmq:
-    image: rabbitmq-4:alpine
+    image: rabbitmq:alpine
     healthcheck:
       test: rabbitmq-diagnostics -q ping
       interval: 30s


### PR DESCRIPTION
Reverts rails/buildkite-config#138

I messed the image URL, which cause CI to soft fails, hence why I thought it worked....