### PR TITLE
Add Ruby 3.4 image to Rails CI

### DIFF
--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -16,7 +16,7 @@ Buildkite::Builder.pipeline do
     build_context.rubies << Buildkite::Config::RubyConfig.master_debug_ruby
     build_context.default_ruby = Buildkite::Config::RubyConfig.master_ruby
   else
-    build_context.setup_rubies %w(2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3 3.4.0-rc1)
+    build_context.setup_rubies %w(2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3 3.4)
   end
 
   group do


### PR DESCRIPTION
This pull request adds Ruby 3.4 image to Rails CI

`ruby:3.4` tag is available.
https://hub.docker.com/layers/library/ruby/3.4/images/sha256-91a6accf150fcb98a5fc3873b1e5c2c3008e39408edb8cb2cebe58a7cde2ce91