### PR TITLE
Experiment with running rails/rails builds on Buildkite Hosted Agents

### DIFF
--- a/lib/buildkite/config/build_context.rb
+++ b/lib/buildkite/config/build_context.rb
@@ -190,7 +190,7 @@ module Buildkite::Config
       end
 
       def remote_image_base
-        "973266071021.dkr.ecr.us-east-1.amazonaws.com/#{"#{build_queue}-" unless standard_queues.include?(build_queue)}builds"
+        ENV.fetch("REGISTRY") + "/#{"#{build_queue}-" unless standard_queues.include?(build_queue)}builds"
       end
   end
 end

--- a/lib/buildkite/config/rake_command.rb
+++ b/lib/buildkite/config/rake_command.rb
@@ -48,6 +48,9 @@ module Buildkite::Config
           ],
           compressed: ".buildkite.tgz"
         }
+        plugin :metahook, {
+          "pre-command": "echo \"+++ inspect docker image store\"\ndocker image ls"
+        }
 
         plugin :docker_compose, {
           "env" => env,

--- a/lib/buildkite/config/rake_command.rb
+++ b/lib/buildkite/config/rake_command.rb
@@ -52,8 +52,7 @@ module Buildkite::Config
         plugin :docker_compose, {
           "env" => env,
           "run" => service,
-          "pull" => service,
-          "pull-retries" => 3,
+          "tty" => "true",
           "config" => ".buildkite/docker-compose.yml",
           "shell" => ["runner", *dir],
         }.compact

--- a/pipelines/rails-ci/initial.yml
+++ b/pipelines/rails-ci/initial.yml
@@ -1,9 +1,15 @@
 # This file is never read -- it's just a copy of the pipeline's
 # configuration in the Buildkite UI.
+env:
+  CONFIG_REPO: "https://github.com/yob/buildkite-config"
+  CONFIG_BRANCH: "hosted"
 
 steps:
   - name: ":pipeline: rails-initial-pipeline"
     command: |
+      echo "Fetching registry details"
+      export REGISTRY="$$(nsc workspace describe -o json -k registry_url)"
+
       PATH=/bin:/usr/bin
       set -e
 
@@ -30,17 +36,22 @@ steps:
       echo "Fetching pull-request metadata:"
       (docker run --rm \
         -v "$$PWD":/app:ro -w /app \
+        -v "$$PWD/cache/bundler":/usr/local/bundle \
         -e GITHUB_PUBLIC_REPO_TOKEN \
         -e BUILDKITE_REPO \
         -e BUILDKITE_PULL_REQUEST \
         ruby:latest \
         .buildkite/bin/fetch-pr > .buildkite/tmp/.pr-meta.json) || true
 
+
       echo "Generating pipeline:"
       sh -c "$$PIPELINE_COMMAND"
 
       ([ -f .buildkite/.dockerignore ] && cp .buildkite/.dockerignore .dockerignore) || true
-
+    cache:
+      paths:
+        - "cache/bundler"
+      name: "rails-initial-bundler-cache"
     plugins:
       - artifacts#v1.9.3:
           upload: ".dockerignore"
@@ -58,6 +69,7 @@ steps:
       PIPELINE_COMMAND: >-
         docker run --rm
         -v "$$PWD":/app:ro -w /app
+        -v "$$PWD/cache/bundler":/usr/local/bundle
         -e CI
         -e BUILDKITE
         -e BUILDKITE_AGENT_META_DATA_QUEUE
@@ -72,9 +84,10 @@ steps:
         -e DOCKER_IMAGE
         -e RUN_QUEUE
         -e QUEUE
+        -e REGISTRY
         ruby:latest
         .buildkite/bin/pipeline-generate rails-ci |
         buildkite-agent pipeline upload
     timeout_in_minutes: 5
     agents:
-      queue: "${QUEUE-builder}"
+      queue: hosted

--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -7,7 +7,7 @@ Buildkite::Builder.pipeline do
   use Buildkite::Config::RakeCommand
   use Buildkite::Config::RubyGroup
 
-  plugin :docker_compose, "docker-compose#v4.16.0"
+  plugin :docker_compose, "docker-compose#v5.4.1"
   plugin :artifacts, "artifacts#v1.9.3"
 
   if build_context.nightly?

--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -9,6 +9,7 @@ Buildkite::Builder.pipeline do
 
   plugin :docker_compose, "docker-compose#v5.4.1"
   plugin :artifacts, "artifacts#v1.9.3"
+  plugin :metahook, "improbable-eng/metahook#v0.4.1"
 
   if build_context.nightly?
     build_context.rubies << Buildkite::Config::RubyConfig.master_ruby


### PR DESCRIPTION
I've started exploring what changes are required to get rails/rails builds running on Buildkite Hosted Agents, and whether there are performance gains to be had. What's here works and runs a green build, but I'm not very familiar with the rails core conventions and preferences so this is an early preview for feedback.

The required changes are are all in the first commit. The second is a helpful debugging tweak that prints the content of the docker image store at the start of the job - helpful for understanding how the caching is working, but I assume we'd drop it before merging.

The high level changes are:

1. Use the agent-local OCI registry rather than ECR
2. We still push the compiled images to the registry at the start of build, and pull it at the start of each subsequent job. However, most layers of the image don't change between builds and in most cases only the changed layers are fetched (== speedy) 
3. In many cases the images for mysql/postgres/rabbitmq/etc will be cached on the agents from previous runs and won't need to be pulled
5. Update docker-compose plugin to the 5.x series

In my testing I've found the builds complete in 5-8 minutes when run on agents with 2vCPU and 4Gb RAM, depending on cache warmth and hit rate.