### PR TITLE
Run rubocop with bundle exec so it use the version in Gemfile.lock

### DIFF
--- a/lib/buildkite/config/rake_command.rb
+++ b/lib/buildkite/config/rake_command.rb
@@ -71,7 +71,7 @@ module Buildkite::Config
         command do
           label label
           depends_on "docker-image-#{build_context.ruby.image_key}"
-          command command
+          command "bundle exec #{command}"
 
           install_plugins
 

--- a/test/buildkite_config/test_rake_command.rb
+++ b/test/buildkite_config/test_rake_command.rb
@@ -425,7 +425,7 @@ class TestRakeCommand < TestCase
     assert_equal "rubocop", step["label"]
     assert_equal "docker-image-ruby-3-2", step["depends_on"][0]
     assert_includes step, "command"
-    assert_equal "rubocop", step["command"][0]
+    assert_equal "bundle exec rubocop", step["command"][0]
 
     plugins = step["plugins"]
 


### PR DESCRIPTION
Somehow the CI is using a rubocop version more recent than the one on the Gemfile.lock:

https://buildkite.com/rails/rails/builds/116952#019541bc-e519-46ec-95fc-e1c2500ff8b6

