### PR TITLE
Use "mariadb:11.4" to workaround CI failure

### DIFF
--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -90,7 +90,7 @@ Buildkite::Builder.pipeline do
         rake "activerecord", task: "mysql2:test",
           service: "mariadb",
           label: "[mariadb]",
-          env: { MYSQL_IMAGE: "mariadb:lts" }
+          env: { MYSQL_IMAGE: "mariadb:11.4" }
 
         rake "activerecord", task: "mysql2:test",
           service: "mysqldb",
@@ -119,7 +119,7 @@ Buildkite::Builder.pipeline do
           rake "activerecord", task: "trilogy:test",
             service: "mariadb",
             label: "[mariadb]",
-            env: { MYSQL_IMAGE: "mariadb:lts" }
+            env: { MYSQL_IMAGE: "mariadb:11.4" }
 
           rake "activerecord", task: "trilogy:test",
             service: "mysqldb",


### PR DESCRIPTION
This commit addresses Rails CI failures https://buildkite.com/rails/rails/builds/119085#01975d87-fe6b-4b0d-8178-0430a34f3376/1283-1291 That is related to https://github.com/rails/rails/issues/53727

To workaround it, docker image tag has been changed from `mariadb:latest` to `mariadb:lts` via https://github.com/rails/buildkite-config/pull/130. At that time `mariadb:lts` uses MariaDB 11.4.

Now `mariadb:lts` image now uses MariaDB 11.8 via https://github.com/MariaDB/mariadb-docker/blob/4c5048803b4785a1ef057c2d4c48b126a08348c6/11.8/Dockerfile We will need to use `mariadb:11.4` that is the previous versions of MariaDB lts that should not be affected by https://github.com/rails/rails/issues/53727