### PR TITLE
Automatically ci-skip if all changed files are md

### DIFF
--- a/lib/buildkite/config/build_context.rb
+++ b/lib/buildkite/config/build_context.rb
@@ -23,9 +23,20 @@ module Buildkite::Config
       ENV.has_key?("RAILS_CI_NIGHTLY")
     end
 
+    def full?
+      # [ci full], [full ci], [ci-full], or [full-ci]
+      [ENV["BUILDKITE_MESSAGE"], FetchPr.title].grep(/(ci full|full ci|ci-full|full-ci)/i).any?
+    end
+
     def skip?
       # [ci skip], [skip ci], [ci-skip], or [skip-ci]
       [ENV["BUILDKITE_MESSAGE"], FetchPr.title].grep(/(ci skip|skip ci|ci-skip|skip-ci)/i).any?
+    end
+
+    def only_markdown?
+      `git diff --name-only $BUILDKITE_PULL_REQUEST_BASE_BRANCH`
+        .lines(chomp: true)
+        .all? { |line| line.end_with? ".md" }
     end
 
     def rails_root

--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -42,7 +42,7 @@ Buildkite::Builder.pipeline do
     end
   end
 
-  if build_context.skip?
+  if !build_context.full? && (build_context.skip? || build_context.only_markdown?)
     command do
       label ":bk-status-passed: Build skipped"
       skip true


### PR DESCRIPTION
Currently, documentation changes require contributors to add a variation of "ci skip" to their pull request in order to not run the full Rails test suite. However, it requires contributors to know about this feature in order to use it (to get faster/less flaky builds).

This commit tries to remove the requirements of that knowledge by automatically skipping the full test suite in some cases (currently when all changed files are markdown).

It also introduces a new opt-out "ci full" which can be used in cases where the automatic opt-out is undesired for some reason.