### PR TITLE
Explicitly use IPv4 in beanstalkd, chrome container health checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,7 +173,7 @@ services:
       context: ./
       dockerfile: Dockerfile.beanstalkd
     healthcheck:
-      test: echo -e "stats\r\n" | nc localhost 11300 || exit 1
+      test: echo -e "stats\r\n" | nc 127.0.0.1 11300 || exit 1
       interval: 10s
       timeout: 10s
       retries: 3
@@ -182,7 +182,7 @@ services:
   chrome:
     image: seleniarm/standalone-chromium:latest
     healthcheck:
-      test: "curl -f http://localhost:4444/ui || exit 1"
+      test: "curl -f http://127.0.0.1:4444/ui || exit 1"
       interval: 10s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
@buildkite is experimenting with moving rails/rails CI to hosted agents. During this migration, we discovered that the beanstalkd container health check fails on hosted agents. We suspect this is due to a difference in how `localhost` resolves between environments. On self-hosted agents, `localhost` resolves to IPv4 (`127.0.0.1`), but on hosted agents it appears to resolve to IPv6 (`::1`). Since beanstalkd only listens on IPv4, `nc localhost 11300` attempts an IPv6 connection which fails. We were able to replicate this failure locally and confirmed that explicitly using `127.0.0.1` resolves it. This change updates the beanstalkd health check to force IPv4 resolution, and also updates the chrome container health check for consistency with the other containers which already use `127.0.0.1`.