### PR TITLE
Disable TLS for MariaDB client in CI Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,6 +105,10 @@ RUN set -ex && echo "--- :ruby: Updating RubyGems and Bundler" \
     && mkdir /rails
 
 WORKDIR /rails
+RUN if mysql --version 2>/dev/null | grep -qi mariadb; then \
+    printf '[client]\nssl=OFF\n' > $HOME/.my.cnf && \
+    chmod 600 $HOME/.my.cnf; \
+    fi
 ENV RAILS_ENV=test RACK_ENV=test
 ENV JRUBY_OPTS="--dev -J-Xmx1024M"
 


### PR DESCRIPTION
This commit addresses the following error when running `rake db:mysql:rebuild` in Rails CI.

https://buildkite.com/rails/rails/builds/124697#019b24fc-84ea-4049-9ecb-af39fdaab23e/1455

```
activerecord: rake db:mysql:rebuild mysql2:test
ERROR 2026 (HY000): TLS/SSL error: self-signed certificate in certificate chain
```

This error only reproduces at Rails CI that uses Debian based image like `ruby:3.4`. It does not reproduce at Rails Nightly CI that uses Ubuntu based image like `rubylang/ruby:master`.

Debian `mysql` client is MariaDB one that enables TLS by default https://mariadb.com/docs/server/security/securing-mariadb/encryption/data-in-transit-encryption/securing-connections-for-client-and-server Disabling TLS at Rails CI should be acceptable.

`ssl=OFF` needs to be specified only for MariaDB mysql client because MySQL mysql client raises the following error.
```
mysql: [ERROR] unknown variable 'ssl=OFF'.
```

Since the Dockerfile removes the apt package information, we need to use `mysql --version` command to see if the client is MariaDB or MySQL one.

https://github.com/rails/buildkite-config/blob/main/Dockerfile#L103-L104

Refer to
https://github.com/rails/rails/pull/56176