### PR TITLE
Update fallback RubyGems version to 3.6.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV CACHE_INVALIDATION=1
 ARG BUNDLER
 ARG RUBYGEMS
 RUN set -ex && echo "--- :ruby: Updating RubyGems and Bundler" \
-    && (gem update --system ${RUBYGEMS:-} || gem update --system 3.3.27) \
+    && (gem update --system ${RUBYGEMS:-} || gem update --system 3.4.22) \
     && ruby --version && gem --version && bundle --version \
     && codename="$(. /etc/os-release; x="${VERSION_CODENAME-${VERSION#*(}}"; echo "${x%%[ )]*}")" \
     && echo "--- :package: Installing system deps for debian '$codename'" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV CACHE_INVALIDATION=1
 ARG BUNDLER
 ARG RUBYGEMS
 RUN set -ex && echo "--- :ruby: Updating RubyGems and Bundler" \
-    && (gem update --system ${RUBYGEMS:-} || gem update --system 3.3.27) \
+    && (gem update --system ${RUBYGEMS:-} || gem update --system 3.6.9) \
     && ruby --version && gem --version && bundle --version \
     && codename="$(. /etc/os-release; x="${VERSION_CODENAME-${VERSION#*(}}"; echo "${x%%[ )]*}")" \
     && echo "--- :package: Installing system deps for debian '$codename'" \


### PR DESCRIPTION
The oldest stable branch still exercised by Rails CI is now **7-2-stable**; 7-1-stable and 7-0-stable have not run since 2026-04-02. 7-2-stable's `required_ruby_version` is **3.1.0**, so the fallback should be the latest RubyGems that still supports Ruby 3.1.0.

That is **3.6.9** — RubyGems 3.7.0 dropped Ruby 3.1 support.

RubyGems 3.6.9 ships **Bundler 2.6.9**, which includes rubygems/rubygems#5535 (gracefully recover from gem activation conflicts in `bundler/inline`). The guides `bug_report_templates` run via `Bundler.unbundled_system`, so on the Ruby 3.1 image they use this default Bundler. With Bundler 2.6.9 they no longer fail when a default gem publishes a new release, e.g.

> You have already activated cgi 0.5.1, but your Gemfile requires cgi 0.5.2 (Gem::LoadError)

(see e.g. `guides (3.1)` in https://buildkite.com/rails/rails/builds/130132, worked around by rails/rails#57849).

The fallback only applies on Ruby 3.1; 8-0-stable / 8-1-stable / main require Ruby 3.2+, where the latest RubyGems installs and the fallback is unused, so this does not affect those branches.

### References
- RubyGems 3.7.0 dropped Ruby 3.1 support — https://blog.rubygems.org/2025/07/16/3.7.0-released.html
- RubyGems 3.6.9 bundles Bundler 2.6.9 — https://blog.rubygems.org/2025/05/13/3.6.9-released.html
- rubygems/rubygems#5535
