### PR TITLE
Add net-http to "prod" dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "buildkite-builder"
 gem "benchmark" # https://github.com/Gusto/buildkite-builder/pull/145
 gem "logger"
+gem "net-http"
 
 group :development do
   gem "buildkit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ DEPENDENCIES
   logger
   minitest
   minitest-mock
+  net-http
   rake
   rubocop
   rubocop-minitest

--- a/lib/buildkite/config/fetch_pr.rb
+++ b/lib/buildkite/config/fetch_pr.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "net/http"
 require "uri"
 
 module Buildkite::Config


### PR DESCRIPTION
It's used in FetchPR to look at a PR's tile/files.

It was previously available as a transitive dependency of `buildkit`, but `buildkit` was moved to `development` and so it now raises an error:

```
Failed to fetch PR title: uninitialized constant Buildkite::Config::FetchPr::Net
Failed to fetch PR files: uninitialized constant Buildkite::Config::FetchPr::Net
```