### PR TITLE
Bump to Node.js v22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN set -ex && echo "--- :ruby: Updating RubyGems and Bundler" \
     && echo "deb [signed-by=/etc/apt/keyrings/postgresql.gpg] http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     # Node apt sources
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
+    && printf '%s\n' 'Package: nodejs' 'Pin: origin deb.nodesource.com' 'Pin-Priority: 1001' > /etc/apt/preferences.d/nodejs \
     # Install all the things
     && apt-get update \
     #  buildpack-deps
@@ -93,7 +94,7 @@ RUN set -ex && echo "--- :ruby: Updating RubyGems and Bundler" \
     #  specific dependencies for the rails build
     && apt-get install -y --no-install-recommends \
         postgresql-client default-mysql-client sqlite3 \
-        git nodejs=18.19.0-1nodesource1 lsof \
+        git nodejs lsof \
         ffmpeg mupdf mupdf-tools poppler-utils \
     # clean up
     && apt-get clean \

--- a/pipelines/buildkite-config/initial.yml
+++ b/pipelines/buildkite-config/initial.yml
@@ -112,11 +112,11 @@ steps:
 
           We have a finite number of CI resources, so we want to avoid unnecessary builds.
       - trigger: "rails-ci"
-        label: ":pipeline: Build Rails 7-0-stable with new config"
+        label: ":pipeline: Build Rails 7-2-stable with new config"
         depends_on: block-rails-ci-stable
         build:
-          message: "[${BUILDKITE_BRANCH} / 7-0-stable] ${BUILDKITE_MESSAGE}"
-          branch: "7-0-stable"
+          message: "[${BUILDKITE_BRANCH} / 7-2-stable] ${BUILDKITE_MESSAGE}"
+          branch: "7-2-stable"
           env:
             CONFIG_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
             CONFIG_BRANCH: "${BUILDKITE_BRANCH}"
@@ -144,11 +144,11 @@ steps:
 
           We have a finite number of CI resources, so we want to avoid unnecessary builds.
       - trigger: "rails-ci-nightly"
-        label: ":pipeline: Build Rails 7-0-stable with new nightly config"
+        label: ":pipeline: Build Rails 7-2-stable with new nightly config"
         depends_on: block-rails-ci-nightly-stable
         build:
-          message: "[${BUILDKITE_BRANCH} / 7-0-stable] ${BUILDKITE_MESSAGE}"
-          branch: "7-0-stable"
+          message: "[${BUILDKITE_BRANCH} / 7-2-stable] ${BUILDKITE_MESSAGE}"
+          branch: "7-2-stable"
           env:
             CONFIG_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
             CONFIG_BRANCH: "${BUILDKITE_BRANCH}"


### PR DESCRIPTION
I originally just wanted to remove the super-specific version pin and switch to a preference file, but v18 is very old, so a general version bump seems like a good idea.

v22 is itself already EOL, but seems like a conservative partial step forward.