### PR TITLE
Action Cable integration testing tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ RUN set -ex && echo "--- :ruby: Updating RubyGems and Bundler" \
     #  specific dependencies for the rails build
     && apt-get install -y --no-install-recommends \
         postgresql-client default-mysql-client sqlite3 \
-        git nodejs lsof \
+        git nodejs iproute2 lsof \
         ffmpeg mupdf mupdf-tools poppler-utils \
     # clean up
     && apt-get clean \

--- a/lib/buildkite/config/rake_command.rb
+++ b/lib/buildkite/config/rake_command.rb
@@ -128,8 +128,10 @@ module Buildkite::Config
 
           timeout_in_minutes build_context.timeout_in_minutes
 
-          if soft_fail || build_context.ruby.soft_fail?
+          if soft_fail == true || build_context.ruby.soft_fail?
             soft_fail true
+          elsif soft_fail
+            soft_fail soft_fail
           end
 
           if parallelism

--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -160,7 +160,9 @@ Buildkite::Builder.pipeline do
       end
 
       if ruby == build_context.default_ruby
-        rake "actioncable", task: "test:integration", retry_on: { exit_status: -1, limit: 3 }
+        rake "actioncable", task: "test:integration",
+          retry_on: [{ exit_status: 3, limit: 1 }, { exit_status: -1, limit: 3 }],
+          soft_fail: [{ exit_status: 3 }]
 
         if build_context.rails_root.join("actionview/Rakefile").read.include?("task :ujs")
           rake "actionview", task: "test:ujs", service: "actionview", retry_on: { exit_status: -1, limit: 3 }

--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -159,10 +159,9 @@ Buildkite::Builder.pipeline do
           soft_fail: true
       end
 
-      # ActionCable and ActiveJob integration tests
-      rake "actioncable", task: "test:integration", retry_on: { exit_status: -1, limit: 3 }
-
       if ruby == build_context.default_ruby
+        rake "actioncable", task: "test:integration", retry_on: { exit_status: -1, limit: 3 }
+
         if build_context.rails_root.join("actionview/Rakefile").read.include?("task :ujs")
           rake "actionview", task: "test:ujs", service: "actionview", retry_on: { exit_status: -1, limit: 3 }
         end

--- a/test/buildkite_config/test_rake_command.rb
+++ b/test/buildkite_config/test_rake_command.rb
@@ -370,6 +370,29 @@ class TestRakeCommand < TestCase
     assert_equal({ "automatic" => [{ "limit" => 1, "exit_status" => 127 }] }, pipeline.to_h["steps"][0]["retry"])
   end
 
+  def test_automatic_retry_on_array
+    pipeline = PipelineFixture.new do
+      build_context.ruby = Buildkite::Config::RubyConfig.new(version: Gem::Version.new("3.2"))
+      use Buildkite::Config::RakeCommand
+
+      build_context.stub(:rails_version, Gem::Version.new("7.1")) do
+        rake "test_automatic_retry_on", retry_on: [
+          { limit: 1, exit_status: 127 },
+          { limit: 3, exit_status: 3 },
+        ]
+      end
+    end
+
+    assert_includes pipeline.to_h["steps"][0], "retry"
+    assert_equal(
+      { "automatic" => [
+        { "limit" => 1, "exit_status" => 127 },
+        { "limit" => 3, "exit_status" => 3 },
+      ] },
+      pipeline.to_h["steps"][0]["retry"]
+    )
+  end
+
   def test_soft_fail
     pipeline = PipelineFixture.new do
       build_context.ruby = Buildkite::Config::RubyConfig.new(version: Gem::Version.new("3.2"))
@@ -382,6 +405,20 @@ class TestRakeCommand < TestCase
 
     assert_includes pipeline.to_h["steps"][0], "soft_fail"
     assert_equal true, pipeline.to_h["steps"][0]["soft_fail"]
+  end
+
+  def test_soft_fail_array
+    pipeline = PipelineFixture.new do
+      build_context.ruby = Buildkite::Config::RubyConfig.new(version: Gem::Version.new("3.2"))
+      use Buildkite::Config::RakeCommand
+
+      build_context.stub(:rails_version, Gem::Version.new("7.1")) do
+        rake "test_soft_fail", soft_fail: [{ exit_status: 127 }]
+      end
+    end
+
+    assert_includes pipeline.to_h["steps"][0], "soft_fail"
+    assert_equal [{ "exit_status" => 127 }], pipeline.to_h["steps"][0]["soft_fail"]
   end
 
   def test_soft_fail_ruby


### PR DESCRIPTION
* Additional dependency for https://github.com/rails/rails/pull/57688
* Don't run integration tests separately for each Ruby version: they're only testing the JS
* Treat exit code 3 as retryable, and then as a soft failure

Closes #119 (sorry to have left that untouched for so long, @zzak 😔)