### PR TITLE
Separately pull compose dependencies so they can be retried

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,7 @@ services:
 
   memcached:
     image: memcached:alpine
+    pull_policy: missing
     healthcheck:
       test: echo stats | nc 127.0.0.1 11211
       interval: 10s
@@ -126,6 +127,7 @@ services:
 
   redis:
     image: redis:alpine
+    pull_policy: missing
     healthcheck:
       test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
       interval: 1s
@@ -133,7 +135,8 @@ services:
       retries: 5
 
   mysql: &mysql-defaults
-    image: "${MYSQL_IMAGE-mysql:latest}"
+    image: "${MYSQL_IMAGE-mysql:lts}"
+    pull_policy: missing
     healthcheck:
       test: mysql -h 127.0.0.1 -P 3306 -e "SELECT 1;"
       interval: 1s
@@ -152,6 +155,7 @@ services:
 
   postgres:
     image: "${POSTGRES_IMAGE-postgres:alpine}"
+    pull_policy: missing
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s
@@ -162,6 +166,7 @@ services:
 
   rabbitmq:
     image: rabbitmq:alpine
+    pull_policy: missing
     healthcheck:
       test: rabbitmq-diagnostics -q ping
       interval: 30s
@@ -181,6 +186,7 @@ services:
 
   chrome:
     image: seleniarm/standalone-chromium:latest
+    pull_policy: missing
     healthcheck:
       test: "curl -f http://127.0.0.1:4444/ui || exit 1"
       interval: 10s

--- a/lib/buildkite/config/build_context.rb
+++ b/lib/buildkite/config/build_context.rb
@@ -184,6 +184,7 @@ module Buildkite::Config
     def automatic_retry_on
       [
         { exit_status: -1, limit: 2 },
+        { exit_status: 18, limit: 2 },
         { exit_status: 255, limit: 2 },
       ]
     end

--- a/lib/buildkite/config/rake_command.rb
+++ b/lib/buildkite/config/rake_command.rb
@@ -58,6 +58,8 @@ module Buildkite::Config
         compose_opts = {
           "env" => env,
           "run" => service,
+          "pull" => [service, "--include-deps"],
+          "pull-retries" => 3,
           "config" => ".buildkite/docker-compose.yml",
           "shell" => ["runner", *dir],
           "tty" => "true",

--- a/pipelines/docs-preview/pipeline.rb
+++ b/pipelines/docs-preview/pipeline.rb
@@ -6,7 +6,7 @@ Buildkite::Builder.pipeline do
   use Buildkite::Config::DockerBuild
 
   plugin :docker, "docker#v5.10.0"
-  plugin :docker_compose, "docker-compose#v5.6.0"
+  plugin :docker_compose, "docker-compose#v5.12.1"
   plugin :artifacts, "artifacts#v1.9.3"
   plugin :secrets, "cluster-secrets#v1.0.0"
 

--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -7,7 +7,7 @@ Buildkite::Builder.pipeline do
   use Buildkite::Config::RakeCommand
   use Buildkite::Config::RubyGroup
 
-  plugin :docker_compose, "docker-compose#v5.6.0"
+  plugin :docker_compose, "docker-compose#v5.12.1"
   plugin :artifacts, "artifacts#v1.9.3"
   plugin :secrets, "cluster-secrets#v1.0.0"
 

--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -161,11 +161,16 @@ Buildkite::Builder.pipeline do
 
       if ruby == build_context.default_ruby
         rake "actioncable", task: "test:integration",
-          retry_on: [{ exit_status: 3, limit: 1 }, { exit_status: -1, limit: 3 }],
+          retry_on: [
+            { exit_status: 3, limit: 1 },
+            { exit_status: 18, limit: 2 },
+            { exit_status: -1, limit: 3 },
+          ],
           soft_fail: [{ exit_status: 3 }]
 
         if build_context.rails_root.join("actionview/Rakefile").read.include?("task :ujs")
-          rake "actionview", task: "test:ujs", service: "actionview", retry_on: { exit_status: -1, limit: 3 }
+          rake "actionview", task: "test:ujs", service: "actionview",
+            retry_on: [{ exit_status: 18, limit: 2 }, { exit_status: -1, limit: 3 }]
         end
       end
 

--- a/test/buildkite_config/test_build_context.rb
+++ b/test/buildkite_config/test_build_context.rb
@@ -633,7 +633,11 @@ class TestBuildContext < TestCase
 
   def test_automatic_retry_on
     sub = create_build_context
-    assert_equal([{ exit_status: -1, limit: 2 }, { exit_status: 255, limit: 2 }], sub.automatic_retry_on)
+    assert_equal([
+      { exit_status: -1, limit: 2 },
+      { exit_status: 18, limit: 2 },
+      { exit_status: 255, limit: 2 },
+    ], sub.automatic_retry_on)
   end
 
   def test_timeout_in_minutes

--- a/test/buildkite_config/test_rake_command.rb
+++ b/test/buildkite_config/test_rake_command.rb
@@ -207,7 +207,7 @@ class TestRakeCommand < TestCase
       plugin.key?(plugins_map[:compose])
     }.fetch(plugins_map[:compose])
 
-    %w[env run config shell tty].each do |key|
+    %w[env run pull pull-retries config shell tty].each do |key|
       assert_includes compose, key
     end
 
@@ -215,6 +215,8 @@ class TestRakeCommand < TestCase
     assert_includes compose["env"], "RACK"
 
     assert_equal "default", compose["run"]
+    assert_equal ["default", "--include-deps"], compose["pull"]
+    assert_equal 3, compose["pull-retries"]
     assert_equal "true", compose["tty"]
     assert_equal ".buildkite/docker-compose.yml", compose["config"]
     assert_equal ["runner", "test"], compose["shell"]
@@ -263,11 +265,13 @@ class TestRakeCommand < TestCase
       plugin.key?(plugins_map[:compose])
     }.fetch(plugins_map[:compose])
 
-    %w[run].each do |key|
+    %w[run pull pull-retries].each do |key|
       assert_includes compose, key
     end
 
     assert_equal "myservice", compose["run"]
+    assert_equal ["myservice", "--include-deps"], compose["pull"]
+    assert_equal 3, compose["pull-retries"]
   end
 
   def test_env_yjit
@@ -489,6 +493,8 @@ class TestRakeCommand < TestCase
 
     refute_includes compose, "env"
     assert_equal "default", compose["run"]
+    assert_equal ["default", "--include-deps"], compose["pull"]
+    assert_equal 3, compose["pull-retries"]
     assert_equal ".buildkite/docker-compose.yml", compose["config"]
     assert_equal ["runner", "."], compose["shell"]
 

--- a/test/buildkite_config/test_rake_command.rb
+++ b/test/buildkite_config/test_rake_command.rb
@@ -129,7 +129,14 @@ class TestRakeCommand < TestCase
     end
 
     assert_includes pipeline.to_h["steps"][0], "retry"
-    assert_equal({ "automatic" => [{ "limit" => 2, "exit_status" => -1 }, { "limit" => 2, "exit_status" => 255 }] }, pipeline.to_h["steps"][0]["retry"])
+    assert_equal(
+      { "automatic" => [
+        { "limit" => 2, "exit_status" => -1 },
+        { "limit" => 2, "exit_status" => 18 },
+        { "limit" => 2, "exit_status" => 255 },
+      ] },
+      pipeline.to_h["steps"][0]["retry"]
+    )
   end
 
   def test_env

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,7 @@ BUILDKITE_CONFIG_ROOT = Pathname.new(File.expand_path("../..", __dir__))
 module TestHelpers
   def plugins_map
     {
-      compose: "docker-compose#v5.6.0",
+      compose: "docker-compose#v5.12.1",
       artifacts: "artifacts#v1.9.3"
     }
   end


### PR DESCRIPTION
We see jobs fail sometimes due to a single docker image pull request timing out; let's wrap those operations with some in-job retries.

On top of that, we can also detect such issues as being `exit 18`, and retry the whole job as well.