### PR TITLE
Work around libxml-ruby build failure on ruby master images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -139,6 +139,7 @@ ADD */*.gemspec tmp/
 ADD .buildkite/.empty tools/*/releaser.gemspec tools/releaser/
 ADD .buildkite/.empty railties/exe/* railties/exe/
 ADD Gemfile Gemfile.lock RAILS_VERSION rails.gemspec ./
+ENV BUNDLE_BUILD__LIBXML___RUBY="--with-cflags=-DONIG_ESCAPE_UCHAR_COLLISION"
 
 RUN rm -f railties/exe/.empty \
     && find railties/exe -maxdepth 0 -type d -empty -exec rmdir '{}' '+' \


### PR DESCRIPTION
### Summary

Nightly builds fail since 2026-07-06 while building the rubylang/ruby:master and :master-debug CI images: `bundle install` cannot compile libxml-ruby.

https://buildkite.com/rails/rails-nightly/builds/4522#019f393b-4212-453f-8f4f-c1a538af23e5

Since ruby/ruby#17671 ("Make T_REGEXP embedded"), `include/ruby/internal/core/rregexp.h` includes `ruby/onigmo.h`, so every C extension that includes `ruby.h` now gets onigmo.h's `#define UChar OnigUChar` macro. The CI images are based on Ubuntu 24.04, whose libxml2 2.9.14 is built with ICU and includes `<unicode/ucnv.h>` from its public headers. ICU's `typedef uint16_t UChar;` then expands to a conflicting redeclaration of `OnigUChar`:

```
/usr/local/include/ruby-4.1.0+4/ruby/onigmo.h:76:16: error: conflicting types
for ‘OnigUChar’; have ‘uint16_t’ {aka ‘short unsigned int’}
   76 | # define UChar OnigUChar
/usr/local/include/ruby-4.1.0+4/ruby/onigmo.h:79:24: note: previous declaration
of ‘OnigUChar’ with type ‘OnigUChar’ {aka ‘unsigned char’}
   79 | typedef unsigned char  OnigUChar;
```

### Workaround

Set `BUNDLE_BUILD__LIBXML___RUBY="--with-cflags=-DONIG_ESCAPE_UCHAR_COLLISION"` so bundler passes the flag when building libxml-ruby. `ONIG_ESCAPE_UCHAR_COLLISION` stops onigmo.h from defining the `UChar` macro, and libxml-ruby does not use the Onigmo API. Using `ENV` rather than `bundle config` bakes the setting into the image, so it also covers `bundle install` runs in `PRE_STEPS` at job runtime.

Verified in a container from the same image digest the failed build used (`rubylang/ruby:master@sha256:7174ce49…`):

- `gem install libxml-ruby` fails with the error above
- `BUNDLE_BUILD__LIBXML___RUBY="--with-cflags=-DONIG_ESCAPE_UCHAR_COLLISION" bundle install` succeeds

Only the ruby master images are affected: on released rubies `ruby.h` does not pull in onigmo.h, so the flag is a no-op there. libxml2 2.12 and later no longer include ICU headers from their public headers, so newer distributions are not affected either.

This is intended to be reverted once the header change is addressed in ruby master.
