### PR TITLE
Add PostgreSQL 10 build

### DIFF
--- a/pipelines/rails-ci/pipeline.rb
+++ b/pipelines/rails-ci/pipeline.rb
@@ -107,6 +107,14 @@ Buildkite::Builder.pipeline do
       end
 
       rake "activerecord", task: "postgresql:test", service: "postgresdb"
+
+      if ruby == build_context.default_ruby && build_context.rails_version >= Gem::Version.new("8.2.x")
+        rake "activerecord", task: "postgresql:test",
+          service: "postgresdb",
+          label: "[postgres_10]",
+          env: { POSTGRES_IMAGE: "postgres:10-alpine" }
+      end
+
       rake "activerecord", task: "sqlite3:test"
 
       if ruby == build_context.default_ruby


### PR DESCRIPTION
Add a postgres:10-alpine build as a safeguard so that Rails keeps working against the minimum supported PostgreSQL version. This time rails/rails#58116 only needed test fixes, but future incompatibilities would land unnoticed without CI running the minimum version.

This should be merged after rails/rails#58116.
